### PR TITLE
don't bail out on finding no runfolders when FTP'ing to instrument for ...

### DIFF
--- a/Changes
+++ b/Changes
@@ -6,6 +6,7 @@ release 75.0
  - updated expected result for a live reference retrieval test following
    a change in the reference genome study field
  - add new staging areas 52 to 55
+ - don't bail out on finding no runfolders when FTP'ing to instrument for update info
 
 release 74.14
  - minor bug fix to lims sample_description

--- a/lib/Monitor/SRS/FTP.pm
+++ b/lib/Monitor/SRS/FTP.pm
@@ -97,9 +97,6 @@ sub get_normal_run_paths {
     my $io      = io($path);
     my $listing = $io->all();
 
-    # Let the caller decide if this is bad news or not.
-    croak "Nothing at all found at $path" if $listing eq q{};
-
     $self->update_latest_contact();
 
     my @run_paths;


### PR DESCRIPTION
...update info

Instruments failing to update when first runfolder location (Runs_D) is empty but there is a runfolder in the secondary location (Runs_E)
