### PR TITLE
one copy of gitver for our repositories

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,6 @@
 CHANGES
 
- - one copy of gitver for our repositories
+ - use git describe directly to avoid need for gitver script
 
 release 77.0
  - the build file and module - code improvements, POD and PBP for the module

--- a/lib/npg_tracking/util/build.pm
+++ b/lib/npg_tracking/util/build.pm
@@ -22,21 +22,11 @@ our $VERSION = '0';
 =cut
 
 sub git_tag {
-  my $version;
-  my $gitver = qq[/software/npg/src/npg_tracking/scripts/gitver];
-  if (!-e $gitver) {
-    carp "$gitver script not found";
-    $version = q[unknown];
-  }
-  if (!-x $gitver) {
-    carp "$gitver script is not executable";
-    $version = q[unknown];
-  }
-  if (!$version) {
-    ##no critic (InputOutput::ProhibitBacktickOperators)
-    $version = `$gitver`;
-    $version =~ s/\s$//smxg;
-  }
+  my $version = q[unknown];
+
+  ##no critic (InputOutput::ProhibitBacktickOperators)
+  $version = `git describe --always --dirty`;
+  $version =~ s/\s$//smxg;
   return $version;
 }
 


### PR DESCRIPTION
Use an absolute rather than a relative path for the giver script to be shared across our npg_\* repositories
