### PR TITLE
Cope with no reference genome info in XML

### DIFF
--- a/lib/st/api/sample.pm
+++ b/lib/st/api/sample.pm
@@ -93,7 +93,7 @@ sub strain {
 sub reference_genome {
     my $self = shift;
     $self->parse();
-    return ($self->get(q[Sample reference genome])||[])->[0] || $self->get(q[Reference Genome])->[0];
+    return ($self->get(q[Sample reference genome])||[])->[0] || ($self->get(q[Reference Genome])||[])->[0];
 }
 
 sub contains_nonconsented_human {

--- a/lib/st/api/study.pm
+++ b/lib/st/api/study.pm
@@ -102,7 +102,7 @@ sub email_addresses_of_owners {
 sub reference_genome {
     my $self = shift;
     $self->parse();
-    return $self->get(q[Reference Genome])->[0];
+    return ($self->get(q[Reference Genome])||[])->[0];
 }
 
 sub alignments_in_bam {


### PR DESCRIPTION
avoid array deref on undef
