### PR TITLE
enforce library_id defined

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,9 +1,11 @@
 CHANGES
 
+release 80.9
  - do not try to infer phix reference from library/sample name
  - correct regular expression for modern MiSeq reagent kits - previously
    part of the id starting from teh dash was not returned by the flowcel_id accessor
    in the short_info role
+ - samplesheet generation: library id shoudl be defined for all samples
 
 release 80.8
  - fix memory leak in the samplesheet driver for st::api::lims -

--- a/lib/npg/samplesheet.pm
+++ b/lib/npg/samplesheet.pm
@@ -196,6 +196,10 @@ sub _build__limsreflist {
       if ($self->_multiple_lanes) {
         push @row, $tmpl->position;
       }
+      my $library_id = $tmpl->library_id;
+      if (!$library_id) {
+        croak 'One of library ids indefined for lane ' . $tmpl->position;
+      }
       push @row, $tmpl->library_id;
       push @row, $tmpl->sample_publishable_name;
       push @row, $ref;


### PR DESCRIPTION
samplesheet generation: library id shoudl be defined for all samples