### PR TITLE
method to transparently return live or dev LIMs base URL

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 CHANGES
 
  - default to in-memory option for SQLite in tests
+ - added a method to transparently return live or dev LIMs base URL
 
 release 80.9
  - do not try to infer phix reference from library/sample name

--- a/lib/st/api/base.pm
+++ b/lib/st/api/base.pm
@@ -16,6 +16,12 @@ our $VERSION = '0';
 sub live_url { return q{http://psd-support.internal.sanger.ac.uk:6600}; }
 sub dev_url  { return q{http://dev.psd.sanger.ac.uk:6610}; }
 
+sub lims_url {
+  my $live = q{live};
+  my $domain = $ENV{'dev'} || $live;
+  return $domain eq $live ? live_url() : dev_url();
+}
+
 sub new {
   my ($class, $ref) = @_;
   $ref ||= {};
@@ -185,10 +191,8 @@ sub read {    ## no critic (ProhibitBuiltinHomonyms)
 
 sub service {
   my ($self) = @_;
-  if($ENV{dev}) {
-    $self->{service} = $ENV{dev};
-  }
-  return (!$self->{service} || $self->{service} eq 'live') ? $self->live():$self->dev();
+  my $path = $self->can(q{path}) ? $self->path() : q{};
+  return join q[/], $self->lims_url, $path;
 }
 
 1;
@@ -244,6 +248,11 @@ st::api::base - a base class for st::api::*
 =head2 dev_url - common part of URL for all dev st services
 
   my $CommonDevURLPart = $oDerived->dev_url();
+
+=head2 lims_url - common part of URL for all LIMs services,
+  transparently handles live/dev environment dependency
+
+  my $CommonURLPart = $oDerived->lims_url();
 
 =head2 service - current service URL
 

--- a/lib/st/api/batch.pm
+++ b/lib/st/api/batch.pm
@@ -11,15 +11,8 @@ __PACKAGE__->mk_accessors(fields());
 
 our $VERSION = '0';
 
-
-sub live {
-    my $self = shift;
-    return $self->live_url()  . q{/batches};
-}
-
-sub dev {
-    my $self = shift;
-    return $self->dev_url()   . q{/batches};
+sub path {
+  return q{batches};
 }
 
 sub fields { return qw(id); }
@@ -46,13 +39,7 @@ st::api::batch - an interface to Sample Tracking batches
   my @aFields = $oBatch->fields();
   my @aFields = <pkg>->fields();
 
-=head2 dev - development service URL
-
-  my $sDevURL = $oBatch->dev();
-
-=head2 live - live service URL
-
-  my $sLiveURL = $oBatch->live();
+=head2 path - object type specific path of object uri
 
 =head1 DIAGNOSTICS
 

--- a/lib/st/api/event.pm
+++ b/lib/st/api/event.pm
@@ -15,14 +15,8 @@ __PACKAGE__->mk_accessors(fields());
 
 our $VERSION = '0';
 
-sub live {
-    my $self = shift;
-    return $self->live_url()  . q{/events};
-}
-
-sub dev {
-    my $self = shift;
-    return $self->dev_url()   . q{/events};
+sub path {
+    return q{events};
 }
 
 sub fields {
@@ -95,13 +89,7 @@ st::api::event - an interface to Sample Tracking events
   my @aFields = $oEvent->fields();
   my @aFields = st::api::event->fields();
 
-=head2 dev - development service URL
-
-  my $sDevURL = $oEvents->dev();
-
-=head2 live - live service URL
-
-  my $sLiveURL = $oEvents->live();
+=head2 path - object type specific path of object uri
 
 =head2 create - post event data to sample tracking
 

--- a/lib/st/api/project.pm
+++ b/lib/st/api/project.pm
@@ -15,14 +15,8 @@ __PACKAGE__->mk_accessors(fields());
 
 our $VERSION = '0';
 
-sub live {
-    my $self = shift;
-    return $self->live_url()  . q{/projects};
-}
-
-sub dev {
-    my $self = shift;
-    return $self->dev_url()   . q{/projects};
+sub path {
+    return q{projects};
 }
 
 sub fields { return qw( id name ); }
@@ -55,13 +49,7 @@ st::api::project - an interface to a project
   my @aFields = $oProject->fields();
   my @aFields = <pkg>->fields();
 
-=head2 dev - development service URL
-
-  my $sDevURL = $oProject->dev();
-
-=head2 live - live service URL
-
-  my $sLiveURL = $oProject->live();
+=head2 path - object type specific path of object uri
 
 =head2 project_cost_code
 

--- a/lib/st/api/sample.pm
+++ b/lib/st/api/sample.pm
@@ -27,14 +27,8 @@ sub _parse_taxon_id {
     return $taxon_id;
 }
 
-sub live {
-    my $self = shift;
-    return $self->live_url()  . q{/samples};
-}
-
-sub dev {
-    my $self = shift;
-    return $self->dev_url()   . q{/samples};
+sub path {
+    return q{samples};
 }
 
 sub fields { return qw( id name gc-content organism scientific-rationale concentration consent_withdrawn ); }
@@ -124,13 +118,7 @@ st::api::sample - an interface to sample lims
     my @aFields = $oSample->fields();
     my @aFields = <pkg>->fields();
 
-=head2 dev - development service URL
-
-    my $sDevURL = $oSample->dev();
-
-=head2 live - live service URL
-
-    my $sLiveURL = $oSample->live();
+=head2 path - object type specific path of object uri
 
 =head2 organism - convenience method for ->get('Organism');
 

--- a/lib/st/api/study.pm
+++ b/lib/st/api/study.pm
@@ -13,14 +13,8 @@ __PACKAGE__->mk_accessors(fields());
 
 our $VERSION = '0';
 
-sub live {
-    my $self = shift;
-    return $self->live_url()  . q{/studies};
-}
-
-sub dev {
-    my $self = shift;
-    return $self->dev_url()   . q{/studies};
+sub path {
+  return q{studies};
 }
 
 sub fields { return qw( id name ); }
@@ -164,13 +158,7 @@ st::api::study - an interface to Sample Tracking studies
   my @aFields = $oStudy->fields();
   my @aFields = <pkg>->fields();
 
-=head2 dev - development service URL
-
-  my $sDevURL = $oStudy->dev();
-
-=head2 live - live service URL
-
-  my $sLiveURL = $oStudy->live();
+=head2 path - object type specific path of object uri
 
 =head2 separate_y_chromosome_data - Does the study have associated samples in which there is Y human DNA data is not been consented for public release.
 

--- a/t/40-st-base.t
+++ b/t/40-st-base.t
@@ -1,6 +1,6 @@
 use strict;
 use warnings;
-use Test::More tests => 6;
+use Test::More tests => 10;
 
 use_ok('st::api::base');
 
@@ -11,6 +11,15 @@ use_ok('st::api::base');
   like($base->dev_url(), qr/dev\.psd/, 'dev_url');
   is((scalar $base->fields()), undef, 'no default fields');
   is($base->primary_key(), undef, 'no default pk');
+
+  is($base->lims_url(), $base->live_url(),'live url returned');
+  is($base->service(),  $base->live_url() . q[/],'live url returned');
+  {
+    local $ENV{'dev'} = 'some';
+    is($base->lims_url(), $base->dev_url(), 'dev url returned');
+    is($base->service(),  $base->dev_url() . q[/],'dev url returned');
+  }
+
 }
 
 1;

--- a/t/40-st-event.t
+++ b/t/40-st-event.t
@@ -22,10 +22,15 @@ use_ok('st::api::event');
 
   isa_ok($ev, 'st::api::event');
   is($ev->entity_name(), 'event', 'entity_name returns event');
-  is($ev->live(), 'http://psd-support.internal.sanger.ac.uk:6600/events',
+
+  is($ev->service(), 'http://psd-support.internal.sanger.ac.uk:6600/events',
     'live url returned');
-  is($ev->dev(), 'http://dev.psd.sanger.ac.uk:6610/events',
-    'dev url returned');
+  {
+    local $ENV{'dev'} = 'some';
+    is($ev->service(), 'http://dev.psd.sanger.ac.uk:6610/events',
+      'dev url returned');
+  }
+
   is($ev->fields(), 'key', 'last of fields is key');
 
   my $XML = q[<?xml version='1.0'?><event><message>Run 10 : %s</message><eventful_id>11</eventful_id><eventful_type>Item</eventful_type><family>%s</family><identifier>10</identifier><key>%s</key><location>4</location></event>];


### PR DESCRIPTION
Added a method to transparently return live or dev LIMs base URL.
We need it whe reporting manual qc results.