### PR TITLE
apache: set dev env var explicitly

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,10 @@
 CHANGES
 
+release 84.4
+ - to avoid the need to create deep directory hierarchy containing www-live
+   for a live server, set dev env variable value for the Apache server
+   explicitly
+
 release 81.3
  - accessor methods for frequently used configuration file entries 
  - status monitor script and staging area daemon definition - allow for

--- a/wtsi_local/envvars
+++ b/wtsi_local/envvars
@@ -16,7 +16,6 @@ echo "Server path: ${NPG_TRACKING_SERVER_PATH}"
 export APACHE_RUN_DIR=${NPG_TRACKING_SERVER_PATH}
 
 export dev='dev'
-if [[ "$NPG_TRACKING_SERVER_PATH" =~ "www-live" ]] ; then dev='live'; fi;
 echo "dev: ${dev}"
 
 export APACHE_LOG_DIR=${NPG_TRACKING_SERVER_PATH}/logs


### PR DESCRIPTION
Currently the upstream of the live apache web server installation should have www-live dir. This change hardcodes the dev environment. A switch to live env should be done explicitly by setting the value of dev variable to live or removing this variable alltogether similar to how we currently change the dev port to live one with a sed comand.

Eliminating the need for the www-live dir should allow for keeping all apache installation inside the dated directory on gseq.  