### PR TITLE
when building bait_path replace croak by a warning message

### DIFF
--- a/lib/npg_tracking/data/bait/find.pm
+++ b/lib/npg_tracking/data/bait/find.pm
@@ -46,8 +46,10 @@ sub _build_bait_path {
   }
   if (scalar @refs > 1) {
     ##no critic (ProhibitParensWithBuiltins)
-    croak 'Multiple references returned: ' . join(q[ ], @refs);
+    ####croak 'Multiple references returned: ' . join(q[ ], @refs);
     ##use critic
+    $self->messages->push('Multiple references returned: ' . join(q[ ], @refs));
+    return;
   }
   my $reference = $refs[0];
   my $repository = $self->ref_repository;

--- a/lib/npg_tracking/data/bait/find.pm
+++ b/lib/npg_tracking/data/bait/find.pm
@@ -46,9 +46,8 @@ sub _build_bait_path {
   }
   if (scalar @refs > 1) {
     ##no critic (ProhibitParensWithBuiltins)
-    ####croak 'Multiple references returned: ' . join(q[ ], @refs);
-    ##use critic
     $self->messages->push('Multiple references returned: ' . join(q[ ], @refs));
+    ##use critic
     return;
   }
   my $reference = $refs[0];


### PR DESCRIPTION
 when building bait_path multiple references now generate a warning message rather than croaking