### PR TITLE
Enable UTF-8 support in SQLite test databases when it is enabled for MySQL.

### DIFF
--- a/lib/npg_testing/db.pm
+++ b/lib/npg_testing/db.pm
@@ -3,7 +3,7 @@ package npg_testing::db;
 use Moose::Role;
 use Carp;
 use English qw{-no_match_vars};
-use YAML qw(LoadFile DumpFile);
+use YAML qw(Load Dump);
 use File::Temp qw(tempdir);
 use File::Spec::Functions qw(catfile);
 use Cwd;
@@ -17,6 +17,13 @@ our $VERSION = '0';
 Readonly::Scalar our $FEATURE_EXTENSION => q[.yml];
 Readonly::Scalar our $TEMP_DIR => q{/tmp};
 
+has 'verbose' =>
+  (is      => 'rw',
+   isa     => 'Bool',
+   default => 1,    # This default preserves current behaviour
+   documentation => 'Print to STDERR information about loading test database ' .
+                    'fixtures.',);
+
 =head1 NAME
 
 npg_testing::db
@@ -27,7 +34,12 @@ npg_testing::db
 
 =head1 DESCRIPTION
 
-A Moose role for creating and loading a test sqlite database using an existing DBIx database binding
+A Moose role for creating and loading a test SQLite database using an
+existing DBIx database binding. The encoding used in the YAML files
+and in the test database is UTF-8. If UTF-8 is enabled for the MySQL
+database (using mysql_enable_utf8 => 1 in the DBI connection attributes),
+then it will be enabled automatically in any temporary SQLite database
+created by the create_test_db method.
 
 =head1 SUBROUTINES/METHODS
 
@@ -66,8 +78,18 @@ sub rs_list2fixture {
         while (my $r = $rs->next) {
             push @rows, {$r->get_columns};
         }
-    }
-    DumpFile(catfile($path,$tname).$FEATURE_EXTENSION, \@rows);
+      }
+
+    my $file_name = catfile($path, $tname).$FEATURE_EXTENSION;
+    my $yml = Dump(\@rows);
+
+    # YAML::LoadFile uses Perl's default non-strict UTF-8 handling. We
+    # want strict handling.
+    open my $out, '>:encoding(UTF-8)', $file_name or
+      croak "Failed to open '$file_name' for writing: $ERRNO";
+    print {$out} $yml, "\n" or croak "Failed to write to '$file_name'";
+    close $out or croak "Failed to close '$file_name': $ERRNO";
+
     return;
 }
 
@@ -101,16 +123,36 @@ sub load_fixtures {
     if (scalar @fixtures == 0) { croak qq[no fixtures found at $path]; }
 
     for my $fx (@fixtures) {
-        my $yml  = LoadFile("$path/$fx");
+        my $file_name = "$path/$fx";
+
+        # YAML::DumpFile uses Perl's default non-strict UTF-8
+        # handling. We want strict handling.
+        my $str = q[];
+        {
+            local $INPUT_RECORD_SEPARATOR = undef;
+
+            open my $fh, '<:encoding(UTF-8)', $file_name or
+              croak "Failed to open '$file_name' for reading: $ERRNO";
+            $str = <$fh>;
+            close $fh or
+              croak "Failed to close '$file_name': $ERRNO";
+        }
+
+        my $yml = Load($str);
         my @temp = split m/[._]/sxm, $fx;
         pop @temp;
         my $table = join q[.], @temp;
         $table =~ s/^(\d)+-//smx;
-        warn "+- Loading $fx into $table\n";
+
+        if ($self->verbose) {
+          carp qq[+- Loading $fx into $table];
+        }
+
         my $rs;
         try {
             $rs = $schema->resultset($table);
-        } catch { #old-style names have to be mapped to DBIx classes
+        } catch {
+            #old-style names have to be mapped to DBIx classes
             ##no critic (ProhibitParensWithBuiltins)
             $table = join q[], map {ucfirst $_} split(/\./smx, $table);
             ##use critic
@@ -127,13 +169,18 @@ sub load_fixtures {
 
 =head2 create_test_db
 
-Creates a temp test database and loads data into it.
+Creates a temp SQLite test database and loads data into it.
 The first argument is a DBIx Schema object full namespace,
 the second is the path to the directory where the fixtures
 are located, the third one is a file name for the temporary
 SQLite database. If the third argument is not given, a randomly
 named file in a temporary directory is used; this file will
 be cleaned up on exit.
+
+If UTF-8 is enabled for the MySQL database (using mysql_enable_utf8 =>
+1 in the DBI connection attributes), then it will be enabled
+automatically in any temporary SQLite database created by the
+this method.
 
 =cut
 sub create_test_db {
@@ -146,13 +193,41 @@ sub create_test_db {
     ##use critic
 
     if (!defined $tmpdbfilename) {
-       $tmpdbfilename = q(:memory:);
+      $tmpdbfilename = q[:memory:];
     }
 
-    my $tmpschema = $schema_package->connect('dbi:SQLite:'.$tmpdbfilename);
+    my $user = undef;
+    my $pass = undef;
+    my $dbattr = {RaiseError => 1};
+
+    if ($self->has_config_file) {
+      # If there is a config file (MySQL) which has UTF-8 enabled,
+      # enable it for SQLite too.
+      if ($self->dbattr->{mysql_enable_utf8}) {
+        $dbattr->{sqlite_unicode} = 1;
+        if ($self->verbose) {
+          carp q[Enabled UTF-8 support for SQLite ] .
+               q[because it is enabled for MySQL];
+        }
+      }
+      else {
+        carp q[UTF-8 support is not enabled for SQLite ] .
+             q[because it is not enabled for MySQL];
+      }
+    }
+    else {
+      # There is no config file, so enable UTF-8 by default.
+      $dbattr->{sqlite_unicode} = 1;
+      if ($self->verbose) {
+        carp q[Enabled UTF-8 support for SQLite];
+      }
+    }
+
+    my $tmpschema = $schema_package->connect('dbi:SQLite:' . $tmpdbfilename,
+                                             $user, $pass, $dbattr);
     $tmpschema->deploy;
     if ($fixtures_path) {
-        $self->load_fixtures($tmpschema,  $fixtures_path);
+        $self->load_fixtures($tmpschema, $fixtures_path);
     } else {
         carp q[Fixtures path undefined in create_test_db];
     }


### PR DESCRIPTION
Check UTF-8 when reading/writing YAML.

Added an option to silence fixture loading chatter.