### PR TITLE
Declared a dependency missing from ClearPress

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -179,6 +179,9 @@ my $builder = $class->new(
                 'JSON::Any'                       => '0',
                 'lib'                             => '0.5565',
                 'Lingua::EN::Inflect'             => 0,
+                ## {{{ This is a ClearPress dependency not declared by ClearPress
+                'Lingua::EN::PluralToSingular'    => 0,
+                ## }}}
                 'Linux::Inotify2'                 => 0,
                 'List::MoreUtils'                 => '0.22',
                 'List::Util'                      => '1.21',


### PR DESCRIPTION
Declared a dependency missing from ClearPress as a workaround for

https://rt.cpan.org/Public/Bug/Display.html?id=111667