### PR TITLE
give priority to known values of primary attributes

### DIFF
--- a/lib/st/api/lims.pm
+++ b/lib/st/api/lims.pm
@@ -287,13 +287,13 @@ sub _driver_package_name {
 for my$m ( @METHODS ){
   __PACKAGE__->meta->add_method($m, sub{
     my$l=shift;
+    if(exists $l->_primary_arguments()->{$m}){
+      return $l->_primary_arguments()->{$m};
+    }
     my$d=$l->driver;
     my$r= $d->can($m) ? $d->$m(@_) : undef;
     if( defined $r and length $r){ #if method exists and it returns a defined and non-empty result
       return $d->$m(@_); # call again here in case it returns different info in list context
-    }
-    if(exists $l->_primary_arguments()->{$m}){
-      return $l->_primary_arguments()->{$m}
     }
     if($m eq q(is_pool)){ # avoid obvious recursion
       return scalar $l->children;


### PR DESCRIPTION
When creating children recursively, avoid repeatedly implicitly building primary attr on a driver.
For ml_warehouse driver, when the id_run attribute is not given on a flowcell level, it is built once on the run level in _cached_children (I believe) and then reused for descendants. In the current version it is built for each descendant.