### PR TITLE
samplesheet daemon: fixed logger; changed reference repository root

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,9 @@
 LIST OF CHANGES
 
+ - Samplesheet daemon:
+     fixed logger;
+     changed reference repository root so that it can be run on a staging host.
+
 release 85.2
  - Added 'sample_accession_numbers' to lims shim
  - Deprecated old accessors for qc outcomes.

--- a/lib/npg_tracking/daemon/samplesheet.pm
+++ b/lib/npg_tracking/daemon/samplesheet.pm
@@ -8,16 +8,20 @@ package npg_tracking::daemon::samplesheet;
 use Moose;
 use Carp;
 use English qw(-no_match_vars);
+use Readonly;
 
 our $VERSION = '0';
 
 extends 'npg_tracking::daemon';
 
+Readonly::Scalar my $REFERENCE_ROOT => '/nfs/srpipe_references';
+
 override '_build_hosts' => sub { return ['sf49-nfs']; };
 ##no critic (RequireInterpolationOfMetachars)
-override 'command'  => sub { return q[perl -e 'use strict; use warnings; use npg::samplesheet::auto;  use Log::Log4perl qw(:easy); BEGIN{ Log::Log4perl->easy_init({level=>$INFO,}); } npg::samplesheet::auto->new()->loop();']; };
+override 'command'  => sub { return q[perl -e 'use strict; use warnings; use npg::samplesheet::auto;  use Log::Log4perl qw(:easy); Log::Log4perl->easy_init($INFO); npg::samplesheet::auto->new()->loop();']; };
 ##use critic
-override 'daemon_name'  => sub { return 'npg_samplesheet_daemon'; };
+override 'daemon_name'     => sub { return 'npg_samplesheet_daemon'; };
+override '_build_env_vars' => sub { return {'NPG_REPOSITORY_ROOT' => $REFERENCE_ROOT}};
 
 no Moose;
 
@@ -35,6 +39,15 @@ npg_tracking::daemon::samplesheet
 Class for a daemon that generates sample sheets.
 
 =head1 SUBROUTINES/METHODS
+
+=head2 daemon_name
+
+=head2 env_vars
+
+ NPG_REPOSITORY_ROOT env. variable is set for the daemon to
+ overwrite the default reference repository on a lustre file
+ file system, which is not mounted on the staging areas hosts,
+ where this daemon is running by default.
 
 =head1 DIAGNOSTICS
 

--- a/t/16-npg_tracking-daemon-samplesheet.t
+++ b/t/16-npg_tracking-daemon-samplesheet.t
@@ -17,9 +17,9 @@ use_ok('npg_tracking::daemon::samplesheet');
 
     my $r = npg_tracking::daemon::samplesheet->new(timestamp => '2013');
     is($r->hosts->[0], q[sf49-nfs], 'default host name');
-    is($r->command, q[perl -e 'use strict; use warnings; use npg::samplesheet::auto;  use Log::Log4perl qw(:easy); BEGIN{ Log::Log4perl->easy_init({level=>$INFO,}); } npg::samplesheet::auto->new()->loop();'], 'command to run');
+    is($r->command, q[perl -e 'use strict; use warnings; use npg::samplesheet::auto;  use Log::Log4perl qw(:easy); Log::Log4perl->easy_init($INFO); npg::samplesheet::auto->new()->loop();'], 'command to run');
     is($r->daemon_name, 'npg_samplesheet_daemon', 'default daemon name');
-    is($r->start(q[sf-1-1-01]), $bash_command . qq[daemon -i -r -a 10 -n npg_samplesheet_daemon --umask 002 -A 10 -L 10 -M 10 -o $log_dir/npg_samplesheet_daemon-] . q[sf-1-1-01-2013.log -- perl -e 'use strict; use warnings; use npg::samplesheet::auto;  use Log::Log4perl qw(:easy); BEGIN{ Log::Log4perl->easy_init({level=>$INFO,}); } npg::samplesheet::auto->new()->loop();'] . $bash_error_command, 'start command');
+    is($r->start(q[sf-1-1-01]), $bash_command . qq[daemon -i -r -a 10 -n npg_samplesheet_daemon --env="NPG_REPOSITORY_ROOT=/nfs/srpipe_references" --umask 002 -A 10 -L 10 -M 10 -o $log_dir/npg_samplesheet_daemon-] . q[sf-1-1-01-2013.log -- perl -e 'use strict; use warnings; use npg::samplesheet::auto;  use Log::Log4perl qw(:easy); Log::Log4perl->easy_init($INFO); npg::samplesheet::auto->new()->loop();'] . $bash_error_command, 'start command');
     is($r->ping, q[daemon --running -n npg_samplesheet_daemon && ((if [ -w /tmp/npg_samplesheet_daemon.pid ]; then touch -mc /tmp/npg_samplesheet_daemon.pid; fi) && echo -n 'ok') || echo -n 'not ok'], 'ping command');
     is($r->stop, q[daemon --stop -n npg_samplesheet_daemon], 'stop command');
 }


### PR DESCRIPTION
Running the currently deployed code to generate a samplesheet on sf49-nfs gives an error - reference repository is not visible.

I have successfully run this fixed daemon on sf49-nfs against a dev tracking database. Log messages appear in the daemon's log as expected. The samplesheet is generated.