### PR TITLE
immutable composition

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -95,6 +95,7 @@ my $builder = $class->new(
                 'DateTime::Format::SQLite'        => 0,
                 'IO::File'                        => 0,
                 'IPC::Open2'                      => 0,
+                'List::Util'                      => 0,
                 'Test::Compile'                   => 0,
                 'Test::Distribution'              => 0,
                 'Test::Deep'                      => '0.103',

--- a/Build.PL
+++ b/Build.PL
@@ -186,8 +186,7 @@ my $builder = $class->new(
                 'Lingua::EN::PluralToSingular'    => 0,
                 ## }}}
                 'Linux::Inotify2'                 => 0,
-                'List::MoreUtils'                 => '0.22',
-                'List::Util'                      => '1.21',
+                'List::MoreUtils'                 => '0.416',
                 'Log::Log4perl'                   => 0,
                 'LWP::UserAgent'                  => '5.823',
                 'Math::Round'                     => '0.06',

--- a/Changes
+++ b/Changes
@@ -1,13 +1,13 @@
 LIST OF CHANGES
 
- - Composition framework - the composition object  should be immutable (as much as
-   it is practically possible in Perl):
-     - functionality for an incremental assembly of a composition moved to 
-       a generic composition factory;
-     - empty compositions are not allowed;
-     - sort is performed by the constructor and removed from other functions;
-     - integrity check when serializing composition;
- - Composition - find uses binary search.
+ - Composition framework - the composition object becomes immutable as long
+   as its components are immutable.
+     - Functionality for an incremental assembly of a composition moved to 
+       a generic composition factory.
+     - Empty compositions are not allowed.
+     - Composition constructor returns a sorted composition.
+     - Public sort function is removed.
+ - Composition - find is implemented as a binary search.
 
 release 85.3
  - Add deployment to GitHub Releases

--- a/Changes
+++ b/Changes
@@ -1,5 +1,14 @@
 LIST OF CHANGES
 
+ - Composition framework - the composition object  should be immutable (as much as
+   it is practically possible in Perl):
+     - functionality for an incremental assembly of a composition moved to 
+       a generic composition factory;
+     - empty compositions are not allowed;
+     - sort is performed by the constructor and removed from other functions;
+     - integrity check when serializing composition;
+ - Composition - find uses binary search.
+
 release 85.3
  - Add deployment to GitHub Releases
  - In order to have correctly versioned files in a distribution,

--- a/MANIFEST
+++ b/MANIFEST
@@ -359,7 +359,7 @@ lib/npg_tracking/illumina/run/short_info.pm
 lib/npg_tracking/monitor/status.pm
 lib/npg_tracking/Schema.pm
 lib/npg_tracking/Schema/Result/Annotation.pm
-lib/npg_tracking/Schema/Result/CostCode.pmx
+lib/npg_tracking/Schema/Result/CostCode.pm
 lib/npg_tracking/Schema/Result/CostGroup.pm
 lib/npg_tracking/Schema/Result/Designation.pm
 lib/npg_tracking/Schema/Result/EntityType.pm

--- a/MANIFEST
+++ b/MANIFEST
@@ -341,6 +341,7 @@ lib/npg_tracking/glossary/composition.pm
 lib/npg_tracking/glossary/composition/component.pm
 lib/npg_tracking/glossary/composition/component/illumina.pm
 lib/npg_tracking/glossary/composition/factory.pm
+lib/npg_tracking/glossary/composition/factory/attributes.pm
 lib/npg_tracking/glossary/composition/factory/rpt.pm
 lib/npg_tracking/glossary/composition/serializable.pm
 lib/npg_tracking/glossary/flowcell.pm
@@ -358,7 +359,7 @@ lib/npg_tracking/illumina/run/short_info.pm
 lib/npg_tracking/monitor/status.pm
 lib/npg_tracking/Schema.pm
 lib/npg_tracking/Schema/Result/Annotation.pm
-lib/npg_tracking/Schema/Result/CostCode.pm
+lib/npg_tracking/Schema/Result/CostCode.pmx
 lib/npg_tracking/Schema/Result/CostGroup.pm
 lib/npg_tracking/Schema/Result/Designation.pm
 lib/npg_tracking/Schema/Result/EntityType.pm
@@ -476,6 +477,7 @@ t/10-npg_testing-db.t
 t/10-npg_testing-html.t
 t/10-npg_tracking-glossary-composition-component-illumina.t
 t/10-npg_tracking-glossary-composition-component.t
+t/10-npg_tracking-glossary-composition-factory-attributes.t
 t/10-npg_tracking-glossary-composition-factory-rpt.t
 t/10-npg_tracking-glossary-composition-factory.t
 t/10-npg_tracking-glossary-composition.t

--- a/lib/npg_tracking/glossary/composition.pm
+++ b/lib/npg_tracking/glossary/composition.pm
@@ -36,13 +36,7 @@ sub BUILD {
 
 sub find {
   my ($self, $c) = @_;
-  return $self->find_in_sorted_array($c);
-}
-
-sub find_in_sorted_array {
-  my ($self, $c, $a) = @_;
-  my @list = $a ? @{$a} : $self->components_list;
-  my @found = bsearch { $_->compare_serialized($c) } @list;
+  my @found = bsearch { $_->compare_serialized($c) } $self->components_list;
   return @found ? $found[0] : undef;
 }
 
@@ -171,13 +165,6 @@ npg_tracking::glossary::composition::component object.
   my $found = $composition->find($component);
 
 Undefined value is returned if nothing was found.
-
-=head2 find_in_sorted_array
-
-As find(), but can take optionally a sorted array to perform a search on.
-  
-  $composition->find_in_sorted_array($component);
-  $composition->find_in_sorted_array($component, $array);
 
 =head2 freeze
 

--- a/lib/npg_tracking/glossary/composition.pm
+++ b/lib/npg_tracking/glossary/composition.pm
@@ -41,9 +41,6 @@ sub find {
 
 sub find_in_sorted_array {
   my ($self, $c, $a) = @_;
-  if ( !(ref $c) || ref =~ /HASH|ARRAY/xms ) {
-    croak q[Object is expected];
-  }
   my @list = $a ? @{$a} : $self->components_list;
   my @found = bsearch { $_->compare_serialized($c) } @list;
   return @found ? $found[0] : undef;

--- a/lib/npg_tracking/glossary/composition.pm
+++ b/lib/npg_tracking/glossary/composition.pm
@@ -4,99 +4,79 @@ use Moose;
 use namespace::autoclean;
 use MooseX::Storage;
 use MooseX::StrictConstructor;
+use List::MoreUtils qw/ bsearch/;
+use Readonly;
 use Carp;
-use List::MoreUtils qw/ any uniq /;
 
 with Storage( 'traits' => ['OnlyWhenBuilt'],
               'format' => '=npg_tracking::glossary::composition::serializable' );
 
 our $VERSION = '0';
 
+Readonly::Scalar my $DIGEST_TYPE => 'md5';
+
 has 'components' => (
+      isa       => 'ArrayRef[Object]',
       traits    => [ qw/Array/ ],
       is        => 'ro',
-      isa       => 'ArrayRef[Object]',
-      default   => sub { [] },
+      required  => 1,
       handles   => {
-          'add_component'     => 'push',
-          'has_no_components' => 'is_empty',
-          'sort_components'   => 'sort_in_place',
-          'find_component'    => 'first',
+          '_sort_components'  => 'sort_in_place',
           'num_components'    => 'count',
+          'components_list'   => 'elements',
                    },
 );
 
-before 'add_component' => sub {
-  my ($self, @components) = @_;
+has '_checksum' => (
+      isa       => 'Str',
+      is        => 'ro',
+      required  => 0,
+      init_arg  => undef,
+      writer    => '_set_checksum',
+);
 
-  if (!@components) {
-    croak 'Nothing to add';
+sub BUILD {
+  my $self = shift;
+  if (scalar @{$self->components} == 0) {
+    croak 'Composition cannot be empty';
   }
-
-  my @seen = ();
-  foreach my $c ( @components ) {
-    _test_attr($c);
-    if ( any { !$c->compare_serialized($_) } @seen ) {
-      croak sprintf 'Duplicate entry in arguments to add: %s', $c->freeze();
-    }
-    if ($self->find($c)) {
-      croak sprintf 'Cannot add component %s, already exists', $c->freeze();
-    }
-    push @seen, $c;
-  }
-};
-
-before 'digest' => sub {
-  my ($self, @args) = @_;
-  if ($self->has_no_components) {
-    croak 'Composition is empty, cannot compute digest';
-  }
-};
-
-before 'freeze' => sub {
-  my ($self, @args) = @_;
-  $self->sort();
-};
-
-before 'freeze2rpt' => sub {
-  my ($self, @args) = @_;
-  $self->sort();
-};
-
-sub component_values4attr {
-  my ($self, $attr) = @_;
-
-  if (!$attr) {
-    croak 'Attribute name is missing';
-  }
-  if ($self->has_no_components) {
-    croak qq[Composition is empty, cannot compute values for $attr];
-  }
-  my @values = uniq grep { defined $_ }  map { $_->can($attr) ? $_->$attr : undef } @{$self->components()};
-  return @values;
+  $self->_sort_components(sub { $_[0]->compare_serialized($_[1]) });
+  $self->_set_checksum($self->digest($DIGEST_TYPE));
+  return;
 }
+
+around 'freeze' => sub {
+  my ($orig, $self, @args) = @_;
+  my $frozen = $self->$orig;
+  if ( $self->_checksum() && ($self->_checksum() ne
+       $self->compute_digest($frozen, $DIGEST_TYPE)) ) {
+    croak 'Composition has changed';
+  }
+  return $frozen;
+};
 
 sub find {
   my ($self, $c) = @_;
+  return $self->find_in_sorted_array($c);
+}
+
+sub find_in_sorted_array {
+  my ($self, $c, $a) = @_;
+  $self->_test_component($c);
+  $a ||= $self->components;
+  my @found = bsearch { $_->compare_serialized($c) } @{$a};
+  return @found ? $found[0] : undef;
+}
+
+sub _test_component {
+  my ($self, $c) = @_;
   if ( !defined $c ) {
-    croak 'Missing argument';
+    croak 'Missing component';
   }
-  _test_attr($c);
-  return $self->find_component( sub { !($c->compare_serialized($_)) } );
-}
-
-sub sort {##no critic (Subroutines::ProhibitBuiltinHomonyms)
-  my $self = shift;
-  $self->sort_components(sub { $_[0]->compare_serialized($_[1]) });
-  return;
-}
-
-sub _test_attr {
-  my $c = shift;
   if ( !(ref $c) || ref =~ /HASH|ARRAY/xms ) {
     croak q[Object is expected];
   }
-  return;
+  return 1;
 }
 
 __PACKAGE__->meta->make_immutable;
@@ -110,8 +90,6 @@ npg_tracking::glossary::composition
 
 =head1 SYNOPSIS
 
-A simple derived class example.
-
   package my::package;
   use Moose;
   use namespace::autoclean;
@@ -119,8 +97,8 @@ A simple derived class example.
 
   has 'composition' => (
     is        => 'ro',
+    required  => 1,
     isa       => 'npg_tracking::glossary::composition',
-    default   => sub { npg_tracking::glossary::composition->new() },
     handles   => {
       'composition_digest' => 'digest',
     }
@@ -129,13 +107,14 @@ A simple derived class example.
   __PACKAGE__->meta->make_immutable;
   1;
   
-A derived class that uses its own attributes to build the composition,
-see npg_tracking::glossary::composition::factory for details.
+A class that uses its own attributes to build the composition,
+see npg_tracking::glossary::composition::factory::attributes for details.
 
   package my::package;
   use Moose;
   use namespace::autoclean;
-  with qw( npg_tracking::glossary::composition::factory );
+  with 'npg_tracking::glossary::composition::factory::attributes' =>
+    => { component_class => 'my::component' };
 
   has 'composition' => (
     is         => 'ro',
@@ -147,14 +126,11 @@ see npg_tracking::glossary::composition::factory for details.
   );
   sub _build_composition {
     my $self = shift;
-    return $self->create_sequence_composition();
+    return $self->create_composition();
   }
  
   __PACKAGE__->meta->make_immutable;
   1;
-
-See also npg_tracking::glossary::rpt::factory for conversion from
-Illumina sequencing specific stringified identifies.
 
 =head1 DESCRIPTION
 
@@ -162,6 +138,10 @@ A base class for a collection of one or more entities (components).
 See npg_tracking::glossary::composition::component for a generic component
 interface and npg_tracking::glossary::composition::component::illumina
 for Illumina sequencing specific implementation.
+
+See npg_tracking::glossary::composition::factory and roles in
+npg_tracking::glossary::composition::factory::* for factory methods to
+generate the composition object.
 
 A file with sequencing data can contain reads obtained in a single
 sequencing run or in a number of runs. The composition describes the origin
@@ -190,31 +170,22 @@ by a composition containing a single component. Thus the data from attempt
 
 =head1 SUBROUTINES/METHODS
 
+=head2 BUILD
+
+An extension for the constructor method. Checks that the composition is
+not empty (error for an empty composition) and sorts the composition
+thus ensuring that the order the components were given to the composition
+factory does not matter.
+
 =head2 components
 
-An array reference of component objects, empty by default, see
-npg_tracking::glossary::composition::component interface. The order of
-the objects in the array is not necessary the order the objects are added
-in, i.e. this array cannot be treated as a queue.
+A reference to a non-empty array of component objects, see
+npg_tracking::glossary::composition::component interface.
+Do not change this array directly.
 
-=head2 add_component
+=head2 components_list
 
-Appends a single component object or a list of component objects
-to the end of the components array.
-
-  $composition->add($component);
-  $composition->add((($component1, $component2));
-
-Gives an error if a list of components contains duplicates or if any of
-the argument components already exists in the components array.
-
-=head2 has_no_components
-
-Returns true if the components array is empty, false otherwise.
-
-  if ($composition->has_no_components()) {
-    print 'No components';
-  }
+A list of component objects.
 
 =head2 num_components
 
@@ -230,13 +201,14 @@ npg_tracking::glossary::composition::component object.
 
   my $found = $composition->find($component);
 
-=head2 sort
+Undefined value is returned if nothing was found.
 
-Sorts components array in place. The comparison is based on the
-compare_serialized method of the npg_tracking::glossary::composition::component
-object.
+=head2 find_in_sorted_array
 
-  $composition->sort();
+As find(), but can take optionally a sorted array to perform a search on.
+  
+  $composition->find_in_sorted_array($component);
+  $composition->find_in_sorted_array($component, $array);
 
 =head2 freeze
 
@@ -244,7 +216,9 @@ Returns a custom canonical (sorted) JSON serialization of the object.
 
 Guaranteed to be the same for a set of components regardless of the
 order the componets were added to the composition. Inherited from
-npg_tracking::glossary::composition::serializable.
+npg_tracking::glossary::composition::serializable. Raises an error
+if the internal signature of the object has changed since the object
+was created.
 
   $composition->freeze();
 
@@ -279,17 +253,6 @@ Gives an error if the components array is empty.
   $composition->digest();      # sha256_hex digest
   $composition->digest('md5'); # md5 digest
 
-=head2 component_values4attr
-
-Returns a list of distinct true attribute values of the components. Takes
-the attribute name as input. An empty list is returned if none of the
-components has this value defined defined. Error if the composition is empty. 
-
-  my @subsets = $composition->component_values4attr('subset');
-
-The caller can enforce that the composition is homogeneous in respect of
-the attribute value.
-
 =head1 DIAGNOSTICS
 
 =head1 CONFIGURATION AND ENVIRONMENT
@@ -306,9 +269,9 @@ the attribute value.
 
 =item namespace::autoclean
 
-=item Carp
+=item Readonly
 
-=item List::MoreUtils
+=item Carp
 
 =back
 
@@ -322,7 +285,7 @@ Marina Gourtovaia E<lt>mg8@sanger.ac.ukE<gt>
 
 =head1 LICENSE AND COPYRIGHT
 
-Copyright (C) 2015 GRL
+Copyright (C) 2016 GRL
 
 This file is part of NPG.
 

--- a/lib/npg_tracking/glossary/composition.pm
+++ b/lib/npg_tracking/glossary/composition.pm
@@ -23,6 +23,7 @@ has 'components' => (
       handles   => {
           '_sort_components'  => 'sort_in_place',
           'num_components'    => 'count',
+          'get_component'     => 'get',
           'components_list'   => 'elements',
                    },
 );
@@ -192,6 +193,12 @@ A list of component objects.
 Returns number of components.
 
   print 'Number of components ' . $composition->num_components();
+
+=head2 get_component
+
+Returns a component at index.
+
+  my $component = $composition->get_component(2);
 
 =head2 find
 

--- a/lib/npg_tracking/glossary/composition/factory.pm
+++ b/lib/npg_tracking/glossary/composition/factory.pm
@@ -26,13 +26,14 @@ has '_closed' => (
       isa       => 'Bool',
       is        => 'ro',
       default   => 0,
-      reader    => 'is_closed',
+      init_arg  => undef,
+      reader    => '_is_closed',
       writer    => '_set_closed',
 );
 
 sub _error_if_closed {
   my $self = shift;
-  if ($self->_closed()) {
+  if ($self->_is_closed()) {
     croak 'Factory closed';
   }
   return;
@@ -63,7 +64,7 @@ sub create_composition {
   $self->_error_if_closed();
   $self->_set_closed(1);
   return npg_tracking::glossary::composition->new(
-    components => $self->_components;
+    components => $self->_components()
   );
 }
 

--- a/lib/npg_tracking/glossary/composition/factory.pm
+++ b/lib/npg_tracking/glossary/composition/factory.pm
@@ -52,7 +52,7 @@ before 'add_component' => sub {
     if ( any { !$c->compare_serialized($_) } @seen ) {
       croak sprintf 'Duplicate entry in arguments to add: %s', $c->freeze();
     }
-    if (npg_tracking::glossary::composition->find_in_sorted_array($c, $self->_components)) {
+    if ( any { !$c->compare_serialized($_) } @{$self->_components} ) {
       croak sprintf 'Cannot add component %s, already exists', $c->freeze();
     }
     push @seen, $c;

--- a/lib/npg_tracking/glossary/composition/factory.pm
+++ b/lib/npg_tracking/glossary/composition/factory.pm
@@ -1,45 +1,73 @@
 package npg_tracking::glossary::composition::factory;
 
-use strict;
-use warnings;
-use MooseX::Role::Parameterized;
-use Class::Load qw/load_class/;
+use Moose;
+use namespace::autoclean;
+use MooseX::StrictConstructor;
+use List::MoreUtils qw/ any /;
 use Carp;
 
 use npg_tracking::glossary::composition;
 
 our $VERSION = '0';
 
-parameter 'component_class' => (
-        isa      => 'Str',
-        required => 1,
+has '_components' => (
+      isa       => 'ArrayRef[Object]',
+      traits    => [ qw/Array/ ],
+      is        => 'ro',
+      required  => 0,
+      init_arg => undef,
+      default   => sub { [] },
+      handles   => {
+          'add_component'     => 'push',
+                   },
 );
 
-role {
-  my $param = shift;
+has '_closed' => (
+      isa       => 'Bool',
+      is        => 'ro',
+      default   => 0,
+      reader    => 'is_closed',
+      writer    => '_set_closed',
+);
 
-  method 'create_component' => sub {
-    my $self = shift;
+sub _error_if_closed {
+  my $self = shift;
+  if ($self->_closed()) {
+    croak 'Factory closed';
+  }
+  return;
+}
 
-    my $class = $param->component_class;
-    load_class($class);
+before 'add_component' => sub {
+  my ($self, @components) = @_;
 
-    my $h = {};
-    for my $attr_obj ( $class->meta->get_all_attributes ) {
-      my $attr = $attr_obj->name;
-      $h->{$attr} = $self->can($attr) && defined $self->$attr ? $self->$attr : undef;
+  $self->_error_if_closed();
+  if (!@components) {
+    croak 'Nothing to add';
+  }
+
+  my @seen = ();
+  foreach my $c ( @components ) {
+    if ( any { !$c->compare_serialized($_) } @seen ) {
+      croak sprintf 'Duplicate entry in arguments to add: %s', $c->freeze();
     }
-
-    return $class->new($h);
-  };
-
-  method 'create_composition' => sub {
-    my $self = shift;
-    my $composition = npg_tracking::glossary::composition->new();
-    $composition->add_component($self->create_component());
-    return $composition;
-  };
+    if (npg_tracking::glossary::composition->find_in_sorted_array($c, $self->_components)) {
+      croak sprintf 'Cannot add component %s, already exists', $c->freeze();
+    }
+    push @seen, $c;
+  }
 };
+
+sub create_composition {
+  my $self = shift;
+  $self->_error_if_closed();
+  $self->_set_closed(1);
+  return npg_tracking::glossary::composition->new(
+    components => $self->_components;
+  );
+}
+
+__PACKAGE__->meta->make_immutable;
 
 1;
 __END__
@@ -58,48 +86,41 @@ npg_tracking::glossary::composition::factory
 
   package my::composition;
   use Moose;
-  with 'npg_tracking::glossary::composition::factory' =>
-    => { component_class => 'my::component' };
+  use npg_tracking::glossary::composition::factory;
 
-  has 'attr_1' => (isa => 'Int', is => 'ro', required => 1,);
-  has 'attr_2' => (isa => 'Str', is => 'ro', required => 0,);
-  has 'composition' => (isa => ' npg_tracking::glossary::composition',
-                        required => 0, lazy_build => 1,);
-  sub _build_composition {
-    my $self = shift;
-    return $self->create_composition();
-  }
-  1;
-
-  package main;
-  use my::composition;
-  my $c = my::composition->new(attr_1 => 2);
-  $c->composition(); # error, cannot satisfy required constraint
-                     # for attr_2 in my::component
-  my $c = my::composition->new(attr_1 => 2, attr_1 => 'apple');
-  $c->composition(); # ok
-  
+  my $factory = npg_tracking::glossary::composition::factory->new();
+  $factory->add_component(my::component->new(attr_1 => 1, attr_2 => 'a'));
+  $factory->add_component(my::component->new(attr_1 => 2, attr_2 => 'b'));
+  my $composition = $factory->create_composition();
 
 =head1 DESCRIPTION
 
-A Moose role providing factory functionality for npg_tracking::glossary::composition::component
-and npg_tracking::glossary::composition type objects. The type of the component to be used
-shoudl be set as the component_class parameter.
+Generic factory functionality for npg_tracking::glossary::composition type objects.
 
 =head1 SUBROUTINES/METHODS
 
-=head2 create_component
+=head2 add_component
 
-Inspects the attributes of the object and returns an instance of
-class specified as the component_class parameter. Populates all
-attributes of component class that are present and defined in the
-class consuming this role. Scalar values are copied, data structures
-and objects are copied by reference. No weak copy for objects.
+Stores a single component object or a list of component objects
+inside the factory.
+
+  $factory->add($component);
+  $factory->add((($component1, $component2));
+
+Gives an error if a list of components contains duplicates or if any of
+the argument components have been already given to this factory.
+
+Cannot be called after the create_composition() method has been called;
+
+=cut
 
 =head2 create_composition
 
-Inspects the attributes of the object and returns an instance of
-npg_tracking::glossary::composition with a single component.
+Returns a composition containing all components added to the factory.
+Can only be called once. The order of the objects in the array is not necessary
+the same as the order the objects were added to the factory.
+
+  $factory->create_composition();
 
 =head1 DIAGNOSTICS
 
@@ -109,15 +130,15 @@ npg_tracking::glossary::composition with a single component.
 
 =over
 
-=item strict
+=item Moose
 
-=item warnings
+=item namespace::autoclean
 
-=item MooseX::Role::Parameterized
-
-=item Class::Load
+=item MooseX::StrictConstructor
 
 =item Carp
+
+=item List::MoreUtils
 
 =back
 
@@ -131,7 +152,7 @@ Marina Gourtovaia E<lt>mg8@sanger.ac.ukE<gt>
 
 =head1 LICENSE AND COPYRIGHT
 
-Copyright (C) 2015 GRL
+Copyright (C) 2016 GRL
 
 This file is part of NPG.
 

--- a/lib/npg_tracking/glossary/composition/factory/attributes.pm
+++ b/lib/npg_tracking/glossary/composition/factory/attributes.pm
@@ -1,4 +1,4 @@
-package npg_tracking::glossary::composition::factory;
+package npg_tracking::glossary::composition::factory::attributes;
 
 use strict;
 use warnings;
@@ -6,7 +6,7 @@ use MooseX::Role::Parameterized;
 use Class::Load qw/load_class/;
 use Carp;
 
-use npg_tracking::glossary::composition;
+use npg_tracking::glossary::composition::factory;
 
 our $VERSION = '0';
 
@@ -35,9 +35,9 @@ role {
 
   method 'create_composition' => sub {
     my $self = shift;
-    my $composition = npg_tracking::glossary::composition->new();
-    $composition->add_component($self->create_component());
-    return $composition;
+    my $factory = npg_tracking::glossary::composition::factory->new();
+    $factory->add_component($self->create_component());
+    return $factory->create_composition();
   };
 };
 
@@ -46,7 +46,7 @@ __END__
 
 =head1 NAME
 
-npg_tracking::glossary::composition::factory
+npg_tracking::glossary::composition::factory::attributes
 
 =head1 SYNOPSIS
 
@@ -58,7 +58,7 @@ npg_tracking::glossary::composition::factory
 
   package my::composition;
   use Moose;
-  with 'npg_tracking::glossary::composition::factory' =>
+  with 'npg_tracking::glossary::composition::factory::attributes' =>
     => { component_class => 'my::component' };
 
   has 'attr_1' => (isa => 'Int', is => 'ro', required => 1,);
@@ -131,7 +131,7 @@ Marina Gourtovaia E<lt>mg8@sanger.ac.ukE<gt>
 
 =head1 LICENSE AND COPYRIGHT
 
-Copyright (C) 2015 GRL
+Copyright (C) 20156GRL
 
 This file is part of NPG.
 

--- a/lib/npg_tracking/glossary/composition/factory/attributes.pm
+++ b/lib/npg_tracking/glossary/composition/factory/attributes.pm
@@ -1,0 +1,151 @@
+package npg_tracking::glossary::composition::factory;
+
+use strict;
+use warnings;
+use MooseX::Role::Parameterized;
+use Class::Load qw/load_class/;
+use Carp;
+
+use npg_tracking::glossary::composition;
+
+our $VERSION = '0';
+
+parameter 'component_class' => (
+        isa      => 'Str',
+        required => 1,
+);
+
+role {
+  my $param = shift;
+
+  method 'create_component' => sub {
+    my $self = shift;
+
+    my $class = $param->component_class;
+    load_class($class);
+
+    my $h = {};
+    for my $attr_obj ( $class->meta->get_all_attributes ) {
+      my $attr = $attr_obj->name;
+      $h->{$attr} = $self->can($attr) && defined $self->$attr ? $self->$attr : undef;
+    }
+
+    return $class->new($h);
+  };
+
+  method 'create_composition' => sub {
+    my $self = shift;
+    my $composition = npg_tracking::glossary::composition->new();
+    $composition->add_component($self->create_component());
+    return $composition;
+  };
+};
+
+1;
+__END__
+
+=head1 NAME
+
+npg_tracking::glossary::composition::factory
+
+=head1 SYNOPSIS
+
+  package my::component;
+  use Moose;
+  has 'attr_1' => (isa => 'Int', is => 'ro', required => 1,);
+  has 'attr_2' => (isa => 'Str', is => 'ro', required => 1,);
+  1;
+
+  package my::composition;
+  use Moose;
+  with 'npg_tracking::glossary::composition::factory' =>
+    => { component_class => 'my::component' };
+
+  has 'attr_1' => (isa => 'Int', is => 'ro', required => 1,);
+  has 'attr_2' => (isa => 'Str', is => 'ro', required => 0,);
+  has 'composition' => (isa => ' npg_tracking::glossary::composition',
+                        required => 0, lazy_build => 1,);
+  sub _build_composition {
+    my $self = shift;
+    return $self->create_composition();
+  }
+  1;
+
+  package main;
+  use my::composition;
+  my $c = my::composition->new(attr_1 => 2);
+  $c->composition(); # error, cannot satisfy required constraint
+                     # for attr_2 in my::component
+  my $c = my::composition->new(attr_1 => 2, attr_1 => 'apple');
+  $c->composition(); # ok
+  
+
+=head1 DESCRIPTION
+
+A Moose role providing factory functionality for npg_tracking::glossary::composition::component
+and npg_tracking::glossary::composition type objects. The type of the component to be used
+shoudl be set as the component_class parameter.
+
+=head1 SUBROUTINES/METHODS
+
+=head2 create_component
+
+Inspects the attributes of the object and returns an instance of
+class specified as the component_class parameter. Populates all
+attributes of component class that are present and defined in the
+class consuming this role. Scalar values are copied, data structures
+and objects are copied by reference. No weak copy for objects.
+
+=head2 create_composition
+
+Inspects the attributes of the object and returns an instance of
+npg_tracking::glossary::composition with a single component.
+
+=head1 DIAGNOSTICS
+
+=head1 CONFIGURATION AND ENVIRONMENT
+
+=head1 DEPENDENCIES
+
+=over
+
+=item strict
+
+=item warnings
+
+=item MooseX::Role::Parameterized
+
+=item Class::Load
+
+=item Carp
+
+=back
+
+=head1 INCOMPATIBILITIES
+
+=head1 BUGS AND LIMITATIONS
+
+=head1 AUTHOR
+
+Marina Gourtovaia E<lt>mg8@sanger.ac.ukE<gt>
+
+=head1 LICENSE AND COPYRIGHT
+
+Copyright (C) 2015 GRL
+
+This file is part of NPG.
+
+NPG is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+=cut

--- a/lib/npg_tracking/glossary/composition/factory/attributes.pm
+++ b/lib/npg_tracking/glossary/composition/factory/attributes.pm
@@ -131,7 +131,7 @@ Marina Gourtovaia E<lt>mg8@sanger.ac.ukE<gt>
 
 =head1 LICENSE AND COPYRIGHT
 
-Copyright (C) 20156GRL
+Copyright (C) 2016 GRL
 
 This file is part of NPG.
 

--- a/lib/npg_tracking/glossary/composition/factory/rpt.pm
+++ b/lib/npg_tracking/glossary/composition/factory/rpt.pm
@@ -5,8 +5,8 @@ use warnings;
 use MooseX::Role::Parameterized;
 use Class::Load qw/load_class/;
 
-use npg_tracking::glossary::composition;
 use npg_tracking::glossary::rpt;
+use npg_tracking::glossary::composition::factory;
 
 our $VERSION = '0';
 
@@ -33,12 +33,11 @@ role {
     my ($self) = @_;
 
     my $rpt_list = $self->rpt_list // q[];
-    my $composition = npg_tracking::glossary::composition->new();
+    my $factory = npg_tracking::glossary::composition::factory->new();
     foreach my $rpt ( @{npg_tracking::glossary::rpt->split_rpts($rpt_list)} ) {
-      $composition->add_component( $self->create_component($rpt) );
+      $factory->add_component( $self->create_component($rpt) );
     }
-
-    return $composition;
+    return $factory->create_composition();
   };
 };
 
@@ -137,7 +136,7 @@ Marina Gourtovaia E<lt>mg8@sanger.ac.ukE<gt>
 
 =head1 LICENSE AND COPYRIGHT
 
-Copyright (C) 2015 GRL
+Copyright (C) 2016 GRL
 
 This file is part of NPG.
 

--- a/lib/npg_tracking/glossary/composition/serializable.pm
+++ b/lib/npg_tracking/glossary/composition/serializable.pm
@@ -50,9 +50,13 @@ sub freeze2rpt {
 
 sub digest {
   my ($self, $digest_type) = @_;
-  my $data = $self->freeze();
+  return $self->compute_digest($self->freeze(), $digest_type);
+}
+
+sub compute_digest {
+  my ($self, $data, $digest_type) = @_;
   return ($digest_type && $digest_type eq 'md5') ?
-          md5_hex $data : sha256_hex $data;
+      md5_hex $data : sha256_hex $data;
 }
 
 sub _pack_custom {
@@ -160,10 +164,17 @@ gives an error. See npg_tracking::glossary::rpt for details.
 
 =head2 digest
 
-Returns a digest of the JSON serialization string.
+Returns a digest of the JSON serialization string for $self.
 
   $p->digest();      # sha256_hex digest
   $p->digest('md5'); # md5 digest
+
+=head2 compute_digest
+
+Returns a digest of an input string.
+
+  $p->compute_digest($string);        # sha256_hex digest
+  $p->compute_digest($string, 'md5'); # md5 digest
 
 =head1 DIAGNOSTICS
 

--- a/lib/npg_tracking/glossary/composition/serializable.pm
+++ b/lib/npg_tracking/glossary/composition/serializable.pm
@@ -212,7 +212,7 @@ Marina Gourtovaia E<lt>mg8@sanger.ac.ukE<gt>
 
 =head1 LICENSE AND COPYRIGHT
 
-Copyright (C) 2015 GRL
+Copyright (C) 2016 GRL
 
 This file is part of NPG.
 

--- a/t/10-npg_tracking-glossary-composition-factory-attributes.t
+++ b/t/10-npg_tracking-glossary-composition-factory-attributes.t
@@ -3,7 +3,7 @@ use warnings;
 use Test::More tests => 3;
 use Test::Exception;
 
-use_ok ('npg_tracking::glossary::composition::factory');
+use_ok ('npg_tracking::glossary::composition::factory::attributes');
 
 subtest 'object with one attr missing' => sub {
   plan tests => 2;
@@ -19,7 +19,7 @@ subtest 'object with one attr missing' => sub {
 
   package npg_tracking::composition::factory::test1;
   use Moose;
-  with 'npg_tracking::glossary::composition::factory' =>
+  with 'npg_tracking::glossary::composition::factory::attributes' =>
     {component_class => 'npg_tracking::composition::component::test'};
 
   has 'composition' => (
@@ -51,7 +51,7 @@ subtest 'object with all required attributes' => sub {
 
   package npg_tracking::composition::factory::test2;
   use Moose;
-  with 'npg_tracking::glossary::composition::factory' =>
+  with 'npg_tracking::glossary::composition::factory::attributes' =>
     {component_class => 'npg_tracking::composition::component::test'};
 
   has 'attr_1' => (isa => 'Int', is => 'ro', required => 1,);

--- a/t/10-npg_tracking-glossary-composition-factory-attributes.t
+++ b/t/10-npg_tracking-glossary-composition-factory-attributes.t
@@ -1,0 +1,83 @@
+use strict;
+use warnings;
+use Test::More tests => 3;
+use Test::Exception;
+
+use_ok ('npg_tracking::glossary::composition::factory');
+
+subtest 'object with one attr missing' => sub {
+  plan tests => 2;
+
+  package npg_tracking::composition::component::test;
+  use Moose;
+  use MooseX::Storage;
+  with Storage( 'traits' => ['OnlyWhenBuilt'],
+                'format' => 'JSON' );
+  has 'attr_1' => (isa => 'Int', is => 'ro', required => 1,);
+  has 'attr_2' => (isa => 'Str', is => 'ro', required => 1,);
+  1;
+
+  package npg_tracking::composition::factory::test1;
+  use Moose;
+  with 'npg_tracking::glossary::composition::factory' =>
+    {component_class => 'npg_tracking::composition::component::test'};
+
+  has 'composition' => (
+    is         => 'ro',
+    isa        => 'npg_tracking::glossary::composition',
+    lazy_build => 1,
+  );
+  sub _build_composition {
+    my $self = shift;
+    return $self->create_composition();
+  }
+  1;
+
+  package main;
+
+  my $t = npg_tracking::composition::factory::test1->new(attr_1 => 1);
+  throws_ok { $t->composition }
+    qr/Attribute \(attr_.\) does not pass the type constraint/,
+    'error when required object attribute is not defined';
+  TODO: { local $TODO = 'Moose on Perl < 5.22 not reporting correct attribute failure?';
+  throws_ok { $t->composition }
+    qr/Attribute \(attr_2\) does not pass the type constraint/,
+    'error when required object attribute is not defined';
+  }
+};
+
+subtest 'object with all required attributes' => sub {
+   plan tests => 5;
+
+  package npg_tracking::composition::factory::test2;
+  use Moose;
+  with 'npg_tracking::glossary::composition::factory' =>
+    {component_class => 'npg_tracking::composition::component::test'};
+
+  has 'attr_1' => (isa => 'Int', is => 'ro', required => 1,);
+  has 'attr_2' => (isa => 'Str', is => 'ro', required => 0,);
+  has 'composition' => (
+    is         => 'ro',
+    isa        => 'npg_tracking::glossary::composition',
+    lazy_build => 1,
+  );
+  sub _build_composition {
+    my $self = shift;
+    return $self->create_composition();
+  }
+  1;
+
+  package main;
+
+  my $t = npg_tracking::composition::factory::test2->new(
+             attr_1 => 1,
+             attr_2 => 'test');
+  ok ($t->composition, 'composition is defined');
+  isa_ok ($t->composition, 'npg_tracking::glossary::composition');
+  isa_ok ($t->composition->components->[0], 'npg_tracking::composition::component::test');
+  is($t->composition->num_components, 1, 'one-component composition');
+  is ($t->composition->freeze, '{"components":[{"attr_1":1,"attr_2":"test"}]}',
+    'correct composition serialization'); 
+};
+
+1;

--- a/t/10-npg_tracking-glossary-composition-factory-attributes.t
+++ b/t/10-npg_tracking-glossary-composition-factory-attributes.t
@@ -74,7 +74,7 @@ subtest 'object with all required attributes' => sub {
              attr_2 => 'test');
   ok ($t->composition, 'composition is defined');
   isa_ok ($t->composition, 'npg_tracking::glossary::composition');
-  isa_ok ($t->composition->components->[0], 'npg_tracking::composition::component::test');
+  isa_ok ($t->composition->get_component(0), 'npg_tracking::composition::component::test');
   is($t->composition->num_components, 1, 'one-component composition');
   is ($t->composition->freeze, '{"components":[{"attr_1":1,"attr_2":"test"}]}',
     'correct composition serialization'); 

--- a/t/10-npg_tracking-glossary-composition-factory.t
+++ b/t/10-npg_tracking-glossary-composition-factory.t
@@ -1,83 +1,60 @@
 use strict;
 use warnings;
-use Test::More tests => 3;
+use Test::More tests => 4;
 use Test::Exception;
 
 use_ok ('npg_tracking::glossary::composition::factory');
 
-subtest 'object with one attr missing' => sub {
+subtest 'empty composition cannot be created' => sub {
   plan tests => 2;
 
-  package npg_tracking::composition::component::test;
-  use Moose;
-  use MooseX::Storage;
-  with Storage( 'traits' => ['OnlyWhenBuilt'],
-                'format' => 'JSON' );
-  has 'attr_1' => (isa => 'Int', is => 'ro', required => 1,);
-  has 'attr_2' => (isa => 'Str', is => 'ro', required => 1,);
-  1;
-
-  package npg_tracking::composition::factory::test1;
-  use Moose;
-  with 'npg_tracking::glossary::composition::factory' =>
-    {component_class => 'npg_tracking::composition::component::test'};
-
-  has 'composition' => (
-    is         => 'ro',
-    isa        => 'npg_tracking::glossary::composition',
-    lazy_build => 1,
-  );
-  sub _build_composition {
-    my $self = shift;
-    return $self->create_composition();
-  }
-  1;
-
-  package main;
-
-  my $t = npg_tracking::composition::factory::test1->new(attr_1 => 1);
-  throws_ok { $t->composition }
-    qr/Attribute \(attr_.\) does not pass the type constraint/,
-    'error when required object attribute is not defined';
-  TODO: { local $TODO = 'Moose on Perl < 5.22 not reporting correct attribute failure?';
-  throws_ok { $t->composition }
-    qr/Attribute \(attr_2\) does not pass the type constraint/,
-    'error when required object attribute is not defined';
-  }
+  my $f = npg_tracking::glossary::composition::factory->new();
+  isa_ok ($f, 'npg_tracking::glossary::composition::factory');
+  throws_ok { $f->create_composition() } qr/Composition cannot be empty/,
+    'empty composition object cannot be created';
 };
 
-subtest 'object with all required attributes' => sub {
-   plan tests => 5;
+subtest 'create non-empty composition' => sub {
+  plan tests => 14;
 
-  package npg_tracking::composition::factory::test2;
-  use Moose;
-  with 'npg_tracking::glossary::composition::factory' =>
-    {component_class => 'npg_tracking::composition::component::test'};
+  my $cpname = q[npg_tracking::glossary::composition::component::illumina];
+  use_ok ("$cpname");
 
-  has 'attr_1' => (isa => 'Int', is => 'ro', required => 1,);
-  has 'attr_2' => (isa => 'Str', is => 'ro', required => 0,);
-  has 'composition' => (
-    is         => 'ro',
-    isa        => 'npg_tracking::glossary::composition',
-    lazy_build => 1,
-  );
-  sub _build_composition {
-    my $self = shift;
-    return $self->create_composition();
-  }
-  1;
+  my $f = npg_tracking::glossary::composition::factory->new();
+  throws_ok { $f->add_component() } qr/Nothing to add/,
+    'no attrs - error';
+  throws_ok { $f->add_component({'one' => 1,}) }
+    qr/A new member value for components does not pass its type constraint/,
+    'wrong type - error';
 
-  package main;
+  my $c = $cpname->new(id_run => 1, position => 2);
+  throws_ok { $f->add_component($c, $c) }
+    qr/Duplicate entry in arguments to add/,
+    'add one component twice in one call';
+  lives_ok { $f->add_component($c) } 'add one component';
+  throws_ok { $f->add_component($c) } qr/already exists/,
+    'error adding the same component second time';
+  my $c = $f->create_composition();
+  isa_ok ($c, 'npg_tracking::glossary::composition');
+  is ($c->num_components, 1, 'one component');
+  my $c1 = $cpname->new(id_run => 1, position => 2, subset => 'all');
+  throws_ok { $f->add_component($c1) }
+    qr/'Factory closed/, 'cannot add further components';
+  throws_ok { $f->create_composition() }
+    qr/'Factory closed/, 'cannot create further compositions';
 
-  my $t = npg_tracking::composition::factory::test2->new(
-             attr_1 => 1,
-             attr_2 => 'test');
-  ok ($t->composition, 'composition is defined');
-  isa_ok ($t->composition, 'npg_tracking::glossary::composition');
-  isa_ok ($t->composition->components->[0], 'npg_tracking::composition::component::test');
-  is($t->composition->num_components, 1, 'one-component composition');
-  is ($t->composition->freeze, '{"components":[{"attr_1":1,"attr_2":"test"}]}',
-    'correct composition serialization'); 
+  $f = npg_tracking::glossary::composition::factory->new();
+  lives_ok { $f->add_component($c);
+             $f->add_component($c1); } 'added two vomponents';
+  $c = $f->create_composition();
+  isa_ok ($c, 'npg_tracking::glossary::composition');
+  is ($c->num_components, 2, 'two components');
+  throws_ok { $f->add_component($c1) }
+    qr/'Factory closed/, 'cannot add further components';
+  throws_ok { $f->create_composition() }
+    qr/'Factory closed/, 'cannot create further compositions';  
 };
+
+
 
 1;

--- a/t/10-npg_tracking-glossary-composition-factory.t
+++ b/t/10-npg_tracking-glossary-composition-factory.t
@@ -2,6 +2,7 @@ use strict;
 use warnings;
 use Test::More tests => 4;
 use Test::Exception;
+use DateTime;
 
 use_ok ('npg_tracking::glossary::composition::factory');
 
@@ -14,45 +15,58 @@ subtest 'empty composition cannot be created' => sub {
     'empty composition object cannot be created';
 };
 
+subtest 'component type is important' => sub {
+  plan tests => 3;
+
+  my $f = npg_tracking::glossary::composition::factory->new();
+  throws_ok { $f->add_component({'one' => 1,}) }
+    qr/does not pass its type constraint/,
+    'component should be an object';
+  lives_ok { $f->add_component(DateTime->now()) }
+    'can add an arbitrary object type to a composition';
+  throws_ok { $f->add_component(DateTime->now()) }
+    qr/Can\'t locate object method "compare_serialized"/,
+    'components should implement "compare_serialized" method';
+};
+
 subtest 'create non-empty composition' => sub {
   plan tests => 14;
-
-  my $cpname = q[npg_tracking::glossary::composition::component::illumina];
-  use_ok ("$cpname");
 
   my $f = npg_tracking::glossary::composition::factory->new();
   throws_ok { $f->add_component() } qr/Nothing to add/,
     'no attrs - error';
-  throws_ok { $f->add_component({'one' => 1,}) }
-    qr/A new member value for components does not pass its type constraint/,
-    'wrong type - error';
 
+  my $cpname = q[npg_tracking::glossary::composition::component::illumina];
+  use_ok ("$cpname");
+
+  $f = npg_tracking::glossary::composition::factory->new();
   my $c = $cpname->new(id_run => 1, position => 2);
   throws_ok { $f->add_component($c, $c) }
     qr/Duplicate entry in arguments to add/,
     'add one component twice in one call';
+
   lives_ok { $f->add_component($c) } 'add one component';
   throws_ok { $f->add_component($c) } qr/already exists/,
     'error adding the same component second time';
-  my $c = $f->create_composition();
-  isa_ok ($c, 'npg_tracking::glossary::composition');
-  is ($c->num_components, 1, 'one component');
+  my $composotion = $f->create_composition();
+  isa_ok ($composotion, 'npg_tracking::glossary::composition');
+  is ($composotion->num_components, 1, 'one component');
   my $c1 = $cpname->new(id_run => 1, position => 2, subset => 'all');
   throws_ok { $f->add_component($c1) }
-    qr/'Factory closed/, 'cannot add further components';
+    qr/Factory closed/, 'cannot add further components';
   throws_ok { $f->create_composition() }
-    qr/'Factory closed/, 'cannot create further compositions';
+    qr/Factory closed/, 'cannot create further compositions';
 
   $f = npg_tracking::glossary::composition::factory->new();
   lives_ok { $f->add_component($c);
              $f->add_component($c1); } 'added two vomponents';
-  $c = $f->create_composition();
-  isa_ok ($c, 'npg_tracking::glossary::composition');
-  is ($c->num_components, 2, 'two components');
+  $composotion = $f->create_composition();
+  isa_ok ($composotion, 'npg_tracking::glossary::composition');
+  is ($composotion->num_components, 2, 'two components');
   throws_ok { $f->add_component($c1) }
-    qr/'Factory closed/, 'cannot add further components';
+    qr/Factory closed/, 'cannot add further components';
   throws_ok { $f->create_composition() }
-    qr/'Factory closed/, 'cannot create further compositions';  
+    qr/Factory closed/, 'cannot create further compositions';  
 };
 
 

--- a/t/10-npg_tracking-glossary-composition.t
+++ b/t/10-npg_tracking-glossary-composition.t
@@ -1,104 +1,89 @@
 use strict;
 use warnings;
-use Test::More tests => 7;
+use Test::More tests => 8;
 use Test::Exception;
 
 my $pname = q[npg_tracking::glossary::composition];
 my $cpname = q[npg_tracking::glossary::composition::component::illumina];
 use_ok ("$pname");
 use_ok ("$cpname");
+  use_ok 'npg_tracking::glossary::composition::factory';
 
 subtest 'empty composition' => sub {
-  plan tests => 8;
-
-  my $c = $cpname->new(id_run => 1, position => 2);
-  my $cmps = $pname->new();
-  isa_ok ($cmps, $pname);
-  is ($cmps->has_no_components, 1, 'composition is empty');
-  is ($cmps->num_components, 0, 'no components');
-  lives_ok { $cmps->find($c) } 'calling find for an empty composition';
-  lives_ok { $cmps->sort() } 'calling sort for an empty composition';
-  throws_ok { $cmps->digest() }
-    qr/Composition is empty, cannot compute digest/, 
-    'digest for an empty composition - error';
-  throws_ok { $cmps->component_values4attr() }
-    qr/Attribute name is missing/, 
-    'no attribute name - error';
-  throws_ok { $cmps->component_values4attr('subset') }
-    qr/Composition is empty, cannot compute values for subset/, 
-    'subsets for an empty composition - error';
+  plan tests => 2;
+ throws_ok {npg_tracking::glossary::composition->new()}
+    qr/Attribute \(components\) is required/,
+    'empty composition object cannot be created';
+  throws_ok {npg_tracking::glossary::composition->new(components => [])}
+    qr/Composition cannot be empty/,
+    'empty composition object cannot be created';
 };
 
-subtest 'adding components' => sub {
-  plan tests => 14;
+subtest 'maintaining composition integrity' => sub {
+  plan tests => 2;
 
-  my $c = $cpname->new(id_run => 1, position => 2);
-  my $cmps = $pname->new();
-  throws_ok { $cmps->add_component() } qr/Nothing to add/,
-    'no attrs - error';
-  throws_ok { $cmps->add_component({'one' => 1,}) }
-    qr/A new member value for components does not pass its type constraint/,
-    'wrong type - error';
-  throws_ok { $cmps->add_component($c, $c) }
-    qr/Duplicate entry in arguments to add/,
-    'add one component twice in one call';
-  lives_ok { $cmps->add_component($c) } 'add one component';
-  is ($cmps->num_components, 1, 'one component is available');
-  ok (!$cmps->has_no_components, 'some components');
-  throws_ok { $cmps->add_component($c) } qr/already exists/,
-    'error adding the same component second time'; 
-
-  is (scalar $cmps->component_values4attr('subset'), 0, 'empty list of subsets');
-  $cmps->add_component($cpname->new(id_run => 1, position => 2, subset => 'all'));
-  is (join(q[ ], $cmps->component_values4attr('subset')), 'all', 'one subset value returned');
-  $cmps->add_component($cpname->new(id_run => 1, position => 2, tag_index => 3, subset => 'human'));
-  is (join(q[ ], $cmps->component_values4attr('subset')), 'all human', 'two subset values returned');
-  $cmps->add_component($cpname->new(id_run => 1, position => 3, tag_index => 0, subset => 'human'));
-  is (join(q[ ], $cmps->component_values4attr('subset')), 'all human', 'two subset values returned');
-  is (join(q[ ], $cmps->component_values4attr('id_run')), '1', 'one run id value returned');
-  is (join(q[ ], $cmps->component_values4attr('tag_index')), '3 0', 'two tag index values returned');
-  is (scalar $cmps->component_values4attr('my_attr'), 0,
-    'empty list of not implemented attribute values');
+  my $composition = $pname->new(
+    components => [$cpname->new(id_run => 1, position => 2)]);
+  lives_ok {$composition->freeze()} 'can serialize composition';
+  push @{$composition->components}, $cpname->new(id_run => 1, position => 3);
+  throws_ok {$composition->freeze()} qr/Composition has changed/,
+    'cannot serialize composition';
 };
 
-subtest 'finding' => sub {
-  plan tests => 3;
+subtest 'finding, counting, returning a list' => sub {
+  plan tests => 10;
 
   my $c = $cpname->new(id_run => 1, position => 2);
-  my $cmps = $pname->new();
-  is($cmps->find($c), undef, 'not found - array empty');
-  $cmps->add_component($c);
+  my $cmps = $pname->new(components => [$c]);
   my $found = $cmps->find($c);
   ok($found && (ref $found eq $cpname), 'found an object');
-  is($cmps->find($cpname->new(id_run => 1, position => 3)), undef, 'not found');
+  my $c1 = $cpname->new(id_run => 1, position => 3);
+  is($cmps->find($c1), undef, 'not found');
+
+  is($cmps->num_components, 1, 'one component');
+  my @l = $cmps->components_list();
+  is(scalar @l, 1, 'one component');
+
+  my $f = npg_tracking::glossary::composition::factory->new();
+  $f->add_component($c, $c1);
+  $cmps = $f->create_composition();
+  $found = $cmps->find($c);
+  is($found->position, 2, 'correct position');
+  ok($found && (ref $found eq $cpname), 'found an object');
+  $found = $cmps->find($c1);
+  is($found->position, 3, 'correct position');
+  ok($found && (ref $found eq $cpname), 'found an object');
+
+  is($cmps->num_components, 2, 'two components');
+  @l = $cmps->components_list();
+  is(scalar @l, 2, 'two components');
 };
 
 subtest 'serialization' => sub {
-  plan tests => 7;
+  plan tests => 6;
 
-  my $cmps = $pname->new();
-  throws_ok {$cmps->digest() }
-    qr/Composition is empty, cannot compute digest/,
-    'digest on an empty composition - error';
-
+  my $f = npg_tracking::glossary::composition::factory->new();
   my $c1 = $cpname->new(subset => 'phix', id_run => 1, position => 2);
   my $c2 = $cpname->new(subset => 'human', id_run => 1, position => 2);
   my $d = '3e11d430bb943e01196a378ede86759d679285c59653999c972f1805effb9ab2';
   my $j = '{"components":[{"id_run":1,"position":2,"subset":"human"},{"id_run":1,"position":2,"subset":"phix"}]}';
   my $md5 = 'a9784a88f7611e1aaa4431ee190c8cf6';
-  $cmps->add_component($c1, $c2);
+  $f->add_component($c1, $c2);
+  my $cmps = $f->create_composition();
   is ($cmps->digest(), $d, 'digest');
   is ($cmps->digest('md5'), $md5, 'md5 digest');
   is ($cmps->freeze(), $j, 'json');
-  $cmps = $pname->new();
-  $cmps->add_component($c2, $c1);
+  
+  $f = npg_tracking::glossary::composition::factory->new();
+  $f->add_component($c2, $c1);
+  $cmps = $f->create_composition();
   is ($cmps->digest(), $d, 'digest is the same');
   is ($cmps->digest('md5'), $md5, 'md5 digest is the same');
   is ($cmps->freeze(), $j, 'json is the same'); 
 };
 
 subtest 'serialization to rpt' => sub {
-  plan tests => 7;
+  plan tests => 6;
 
   package test::npg_tracking::component;
   use Moose;
@@ -121,21 +106,18 @@ subtest 'serialization to rpt' => sub {
     qr/Either id_run or position key is undefined /,
     'failure to serialize component without core illumina attr';
 
-  my $cmps = $pname->new();
-  is ($cmps->freeze2rpt, q[], 'empty rpt composition string');
-  $cmps->add_component($c2);
-  $cmps->add_component($c1);
-  is ($cmps->freeze2rpt, '1:2;1:3:6', 'rpt composition string');
+  my $f = npg_tracking::glossary::composition::factory->new();
+  $f->add_component($c1, $c2);
+  is ($f->create_composition()->freeze2rpt, '1:2;1:3:6', 'rpt composition string');
 
-  $cmps = $pname->new();
-  $cmps->add_component($c1);
-  $cmps->add_component($c2);
-  is ($cmps->freeze2rpt, '1:2;1:3:6',
+  $f = npg_tracking::glossary::composition::factory->new();
+  $f->add_component($c2, $c1);
+  is ($f->create_composition()->freeze2rpt, '1:2;1:3:6',
    'no dependency on the order components were added');
 
-  $cmps = $pname->new();
-  $cmps->add_component($c3);
-  throws_ok {$cmps->freeze2rpt}
+  $f = npg_tracking::glossary::composition::factory->new();
+  $f->add_component($c3);
+  throws_ok {$f->create_composition()->freeze2rpt}
     qr/Either id_run or position key is undefined/,
     'failure to serialize component without core illumina attr';
 };

--- a/t/10-npg_tracking-glossary-composition.t
+++ b/t/10-npg_tracking-glossary-composition.t
@@ -20,14 +20,17 @@ subtest 'empty composition' => sub {
 };
 
 subtest 'maintaining composition integrity' => sub {
-  plan tests => 2;
+  plan tests => 3;
 
   my $composition = $pname->new(
     components => [$cpname->new(id_run => 1, position => 2)]);
   lives_ok {$composition->freeze()} 'can serialize composition';
-  push @{$composition->components}, $cpname->new(id_run => 1, position => 3);
-  throws_ok {$composition->freeze()} qr/Composition has changed/,
-    'cannot serialize composition';
+  throws_ok { push @{$composition->components}, $cpname->new(id_run => 1, position => 3)}
+    qr/Can\'t locate object method "components"/,
+    'cannot push directly to the components array';
+  throws_ok { $composition->components->[0] = 3 }
+    qr/Can\'t locate object method "components"/,
+    'cannot reassign a component';
 };
 
 subtest 'getting, finding, counting, returning a list' => sub {

--- a/t/10-npg_tracking-glossary-composition.t
+++ b/t/10-npg_tracking-glossary-composition.t
@@ -30,8 +30,8 @@ subtest 'maintaining composition integrity' => sub {
     'cannot serialize composition';
 };
 
-subtest 'finding, counting, returning a list' => sub {
-  plan tests => 10;
+subtest 'getting, finding, counting, returning a list' => sub {
+  plan tests => 17;
 
   my $c = $cpname->new(id_run => 1, position => 2);
   my $cmps = $pname->new(components => [$c]);
@@ -39,6 +39,9 @@ subtest 'finding, counting, returning a list' => sub {
   ok($found && (ref $found eq $cpname), 'found an object');
   my $c1 = $cpname->new(id_run => 1, position => 3);
   is($cmps->find($c1), undef, 'not found');
+  isa_ok($cmps->get_component(0), $cpname, 'retrieved component');
+  is($cmps->get_component(1), undef, 'retrieved undefined');
+  isa_ok($cmps->get_component(-1), $cpname, 'retrieved component');
 
   is($cmps->num_components, 1, 'one component');
   my @l = $cmps->components_list();
@@ -55,6 +58,11 @@ subtest 'finding, counting, returning a list' => sub {
   ok($found && (ref $found eq $cpname), 'found an object');
 
   is($cmps->num_components, 2, 'two components');
+  isa_ok($cmps->get_component(0), $cpname, 'retrieved component');
+  isa_ok($cmps->get_component(1), $cpname, 'retrieved component');
+  my $last = $cmps->get_component(-1);
+  isa_ok($last, $cpname, 'retrieved component');
+  is($last->position, 3, 'correct position');
   @l = $cmps->components_list();
   is(scalar @l, 2, 'two components');
 };

--- a/t/10-npg_tracking-glossary-composition.t
+++ b/t/10-npg_tracking-glossary-composition.t
@@ -34,10 +34,20 @@ subtest 'maintaining composition integrity' => sub {
 };
 
 subtest 'getting, finding, counting, returning a list' => sub {
-  plan tests => 17;
+  plan tests => 20;
 
   my $c = $cpname->new(id_run => 1, position => 2);
   my $cmps = $pname->new(components => [$c]);
+
+  throws_ok { $cmps->find() } qr/Object to compare to should be given/,
+    'argument is needed';
+  throws_ok { $cmps->find(2) }
+    qr/Expect object of class npg_tracking::glossary::composition::component::illumina/,
+    'argument should be a component of teh same class';
+  throws_ok { $cmps->find([1, 2]) }
+    qr/Expect object of class npg_tracking::glossary::composition::component::illumina/,
+    'argument should be a component of the same class';
+    
   my $found = $cmps->find($c);
   ok($found && (ref $found eq $cpname), 'found an object');
   my $c1 = $cpname->new(id_run => 1, position => 3);


### PR DESCRIPTION
…e (as much as

   it is practically possible in Perl):
     - functionality for an incremental assembly of a composition moved to
       a generic composition factory;
     - empty compositions are not allowed;
     - sort is performed by the constructor and removed from other functions;
     - integrity check when serializing composition;
 - Composition - find uses binary search.
 - Required version of List::MoreUtils increased to make binary search available.