### PR TITLE
drop separate webinstall

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -37,18 +37,16 @@ my $class = WTSI::DNAP::Utilities::Build->subclass(code => <<'EOF');
 
   sub process_cgibin_files {
     my $self = shift;
-    my $files = $self->rscan_dir('cgi-bin', sub {-f $_});
-    my $blib  = $self->blib();
-    foreach my $file ( @{$files} ) {
+    foreach my $file ( @{$self->rscan_dir('cgi-bin', sub {-f $_})} ) {
       my $dest_file = $self->copy_if_modified(
         from    => $file,
-        to_dir  => join(q[/], $self->base_dir(), $blib),
+        to_dir  => join(q[/], $self->base_dir(), $self->blib()),
         flatten => 0);
       if ($dest_file) {
         $self->fix_shebang_line($dest_file);
+        `chmod +x $dest_file`;
       }
     }
-    `chmod +x ${blib}/cgi-bin/*`;
     return;
   }
 
@@ -239,7 +237,7 @@ foreach my $path (qw(data htdocs cgi-bin wtsi_local)) {
   $name =~ s/-//;
   $builder->add_build_element($name);
   if ($builder->install_base()) {
-    $builder->install_path($name => join q{/}, $builder->install_base(), $path);
+    $builder->install_path($path => join q{/}, $builder->install_base(), $path);
   }
 }
 

--- a/Build.PL
+++ b/Build.PL
@@ -6,69 +6,67 @@ use WTSI::DNAP::Utilities::Build;
 
 my $class = WTSI::DNAP::Utilities::Build->subclass(code => <<'EOF');
 
- sub dir_files {
-    my $dir = shift;
-    opendir my $dh, $dir || die "can't opendir $dir: $!";
-    my @files = map { "$dir/$_" } grep { /^\w+$/ && -f "$dir/$_" } readdir $dh;
-    closedir $dh;
-    return @files;
-  }
-
   sub process_data_files {
     my $self = shift;
-    `find data/npg_tracking_email/templates -type f | cpio -pdv --quiet blib`;
-    if ($self->invoked_action() eq q[webinstall]) {
-      `find data/templates -type f | cpio -pdv --quiet blib`;
-      `find data/gfx -type f | cpio -pdv --quiet blib`;
+    my @files  = @{ $self->rscan_dir('data/templates',
+                                     sub {-f $_ and /\.tt2$/}) };
+    push @files, @{ $self->rscan_dir('data/npg_tracking_email/templates',
+                                     sub {-f $_ and /\.tt2$/}) };
+    push @files, @{ $self->rscan_dir('data/gfx',
+                                     sub {-f $_ and /\.png$/}) };
+    foreach my $f ( @files ) {
+      $self->copy_if_modified(
+        from    => $f,
+        to_dir  => join(q[/], $self->base_dir(), $self->blib()),
+        flatten => 0);
     }
     return;
   }
 
   sub process_htdocs_files {
-    `find htdocs -type f | cpio -pdv --quiet blib`;
+    my $self = shift;
+    my $files = $self->rscan_dir('htdocs', sub {-f $_ and (/\.css$/ or /\.js$/)});
+    foreach my $f (@{$files}) {
+      $self->copy_if_modified(
+        from    => $f,
+        to_dir  => join(q[/], $self->base_dir(), $self->blib()),
+        flatten => 0);
+    }
     return;
   }
 
-  sub process_cgi_files {
+  sub process_cgibin_files {
     my $self = shift;
-    my @files = dir_files('cgi-bin');
-    foreach my $file (@files) {
-      my $dest_file = $self->copy_if_modified('from' => $file, 'to_dir' => 'blib');
+    my $files = $self->rscan_dir('cgi-bin', sub {-f $_});
+    my $blib  = $self->blib();
+    foreach my $file ( @{$files} ) {
+      my $dest_file = $self->copy_if_modified(
+        from    => $file,
+        to_dir  => join(q[/], $self->base_dir(), $blib),
+        flatten => 0);
       if ($dest_file) {
         $self->fix_shebang_line($dest_file);
       }
     }
-    `chmod +x blib/cgi-bin/*`;
+    `chmod +x ${blib}/cgi-bin/*`;
     return;
   }
 
-  sub process_wtsilocal_files {
-    `find wtsi_local -type f | cpio -pdv --quiet blib`;
-    return;
-  }
-
-  sub ACTION_webinstall {
+  sub process_wtsi_local_files {
     my $self = shift;
-    if (!$self->install_base()) {
-      warn "WARNING: '--install_base' option is not given, nothing to do for the 'webinstall' action\n\n";
-      return;
+    foreach my $file ( @{$self->rscan_dir('wtsi_local', sub {-f $_})} ) {
+      $self->copy_if_modified(
+        from => $file,
+        to_dir  => join(q[/], $self->base_dir(), $self->blib()),
+        flatten => 0);
     }
-
-    $self->install_path('htdocs' => join q{/}, $self->install_base(), 'htdocs');
-    $self->add_build_element('htdocs');
-    $self->install_path('cgi-bin' => join q{/}, $self->install_base(), 'cgi-bin');
-    $self->add_build_element('cgi');
-    $self->install_path('wtsi_local' => join q{/}, $self->install_base(), 'wtsi_local');
-    $self->add_build_element('wtsilocal');
-    $self->depends_on('install');
-
     return;
   }
 
   sub ACTION_install {
     my $self = shift;
     $self->SUPER::ACTION_install;
-    my$config_path = $self->install_path->{'data'}.'/npg_tracking';
+    my$config_path = join q[/], $self->install_path->{'data'}, 'npg_tracking';
     if(not -e $config_path) {
       warn "WARNING: There is no existing config file installed at $config_path so it is likely stuff will NOT work\n";
     }
@@ -235,8 +233,15 @@ my $builder = $class->new(
             },
          );
 
-$builder->install_path('data' => join q{/}, $builder->install_base() || (), 'data');
-$builder->add_build_element('data');
+# Build and install cgi-related files
+foreach my $path (qw(data htdocs cgi-bin wtsi_local)) {
+  my $name = $path;
+  $name =~ s/-//;
+  $builder->add_build_element($name);
+  if ($builder->install_base()) {
+    $builder->install_path($name => join q{/}, $builder->install_base(), $path);
+  }
+}
 
 $builder->create_build_script();
 

--- a/Changes
+++ b/Changes
@@ -1,5 +1,7 @@
 LIST OF CHANGES
 
+ - Install all files, including cgi-related, within the install action.
+
 release 85.4
  - Run/instrument tracking; added full support for HiSeq 4000 and limited support
    for NextSeq and MiniSeq


### PR DESCRIPTION
Install all files, including files for the web app, in one go withing the "install" action.
To avoid excessive verbal output, use Module::Build methods to find and copy files.