### PR TITLE
Allow the samplesheet path to be determined by the environment

### DIFF
--- a/lib/st/api/lims.pm
+++ b/lib/st/api/lims.pm
@@ -262,9 +262,8 @@ sub _build_driver_type {
     return $type;
   }
 
-  $self->_driver_arguments()->{'path'} ||= $ENV{$CACHED_SAMPLESHEET_FILE_VAR_NAME};
-  if ( $self->_driver_arguments()->{'path'} ) {
-    return $SAMPLESHEET_DRIVER_TYPE;
+  if ($ENV{$CACHED_SAMPLESHEET_FILE_VAR_NAME}) {
+    return 'samplesheet';
   }
 
   return $DEFAULT_DRIVER_TYPE;

--- a/lib/st/api/lims.pm
+++ b/lib/st/api/lims.pm
@@ -57,7 +57,7 @@ as this object's accessors. Example:
 
 =cut
 
-Readonly::Scalar my $CACHED_SAMPLESHEET_FILE_VAR_NAME => 'NPG_CACHED_SAMPLESHEET_FILE';
+Readonly::Scalar our $CACHED_SAMPLESHEET_FILE_VAR_NAME => 'NPG_CACHED_SAMPLESHEET_FILE';
 Readonly::Scalar my $DEFAULT_DRIVER_TYPE              => 'xml';
 Readonly::Scalar my $SAMPLESHEET_DRIVER_TYPE          => 'samplesheet';
 
@@ -263,7 +263,7 @@ sub _build_driver_type {
   }
 
   if ($ENV{$CACHED_SAMPLESHEET_FILE_VAR_NAME}) {
-    return 'samplesheet';
+    return $SAMPLESHEET_DRIVER_TYPE;
   }
 
   return $DEFAULT_DRIVER_TYPE;

--- a/lib/st/api/lims/samplesheet.pm
+++ b/lib/st/api/lims/samplesheet.pm
@@ -40,8 +40,6 @@ Readonly::Scalar  my  $NOT_INDEXED_FLAG             => q[NO_INDEX];
 Readonly::Scalar  my  $RECORD_SPLIT_LIMIT           => -1;
 Readonly::Scalar  my  $DATA_SECTION                 => q[Data];
 Readonly::Scalar  my  $HEADER_SECTION               => q[Header];
-Readonly::Scalar  my  $CACHED_SAMPLESHEET_FILE_VAR_NAME =>
-  q[NPG_CACHED_SAMPLESHEET_FILE];
 
 =head2 path
 
@@ -59,7 +57,7 @@ has 'path' => (
 sub _build_path {
   my $self = shift;
 
-  return $ENV{$CACHED_SAMPLESHEET_FILE_VAR_NAME};
+  return $ENV{$st::api::lims::CACHED_SAMPLESHEET_FILE_VAR_NAME};
 }
 
 =head2 id_run

--- a/lib/st/api/lims/samplesheet.pm
+++ b/lib/st/api/lims/samplesheet.pm
@@ -40,6 +40,8 @@ Readonly::Scalar  my  $NOT_INDEXED_FLAG             => q[NO_INDEX];
 Readonly::Scalar  my  $RECORD_SPLIT_LIMIT           => -1;
 Readonly::Scalar  my  $DATA_SECTION                 => q[Data];
 Readonly::Scalar  my  $HEADER_SECTION               => q[Header];
+Readonly::Scalar  my  $CACHED_SAMPLESHEET_FILE_VAR_NAME =>
+  q[NPG_CACHED_SAMPLESHEET_FILE];
 
 =head2 path
 
@@ -50,7 +52,15 @@ has 'path' => (
                   isa => 'NpgTrackingReadableFile',
                   is  => 'ro',
                   required => 1,
+                  builder  => '_build_path',
+                  lazy     => 1,
 );
+
+sub _build_path {
+  my $self = shift;
+
+  return $ENV{$CACHED_SAMPLESHEET_FILE_VAR_NAME};
+}
 
 =head2 id_run
 


### PR DESCRIPTION
These changes permit the samplesheet driver to find its samplesheet file path correctly from `NPG_CACHED_SAMPLESHEET_FILE` when necessary.

I moved the automatic setting of the path attribute from within the `st::api::lims::driver_type` builder  to its own builder method in `st::api::lims::samplesheet`.

I altered the tests to reflect that the `driver_type => 'samplesheet'` initarg alone may be used to set the driver type of `st::api::lims`, the samplesheet file `path` initarg no longer being required to pass to the driver's constructor.