### PR TITLE
test fixes to ensure a pass under Clearpress v. 475.1.20

### DIFF
--- a/t/20-view-administration.t
+++ b/t/20-view-administration.t
@@ -1,5 +1,6 @@
 use strict;
 use warnings;
+use HTTP::Headers;
 use English qw(-no_match_vars);
 use t::util;
 use npg::model::administration;
@@ -12,11 +13,10 @@ my $util  = t::util->new({fixtures => 1, cgi => CGI->new() });
 {
   my $view = npg::view::administration->new({
                util   => $util,
-               model  => npg::model::administration->new({
-                      util => $util,
-                           }),
+               model  => npg::model::administration->new({util => $util}),
                action => q{list},
                aspect => q{},
+               headers => HTTP::Headers->new()
               });
 
   $util->requestor('public');
@@ -36,11 +36,10 @@ my $util  = t::util->new({fixtures => 1, cgi => CGI->new() });
 {
   my $view = npg::view::administration->new({
                util   => $util,
-               model  => npg::model::administration->new({
-                      util => $util,
-                           }),
+               model  => npg::model::administration->new({util => $util}),
                action => q{create},
                aspect => q{create_instrument_mod},
+               headers => HTTP::Headers->new()
               });
   $util->requestor('public');
   my $render;
@@ -59,11 +58,10 @@ my $util  = t::util->new({fixtures => 1, cgi => CGI->new() });
 
   my $view = npg::view::administration->new({
                util   => $util,
-               model  => npg::model::administration->new({
-                      util => $util,
-                           }),
+               model  => npg::model::administration->new({util => $util}),
                action => q{create},
                aspect => q{create_instrument_mod},
+               headers => HTTP::Headers->new()
               });
   $util->requestor('joe_engineer');
   my $render;
@@ -91,6 +89,7 @@ my $util  = t::util->new({fixtures => 1, cgi => CGI->new() });
     model => npg::model::administration->new({ util => $util }),
     action => q{create},
     aspect => q{create_instrument_mod},
+    headers => HTTP::Headers->new()
   });
   eval { $render = $view->render(); };
   like($EVAL_ERROR, qr{description\ \(\)\ and\/or\ revision\ \(rgb\)\ is\ missing}, 'croaked - missing description');
@@ -108,6 +107,7 @@ my $util  = t::util->new({fixtures => 1, cgi => CGI->new() });
     model => npg::model::administration->new({ util => $util }),
     action => q{create},
     aspect => q{create_instrument_status},
+    headers => HTTP::Headers->new()
   });
   $util->requestor('joe_engineer');
   my $render;
@@ -133,6 +133,7 @@ my $util  = t::util->new({fixtures => 1, cgi => CGI->new() });
     model => npg::model::administration->new({ util => $util }),
     action => q{create},
     aspect => q{create_user},
+    headers => HTTP::Headers->new()
   });
   $util->requestor('joe_admin');
   my $render;
@@ -160,6 +161,7 @@ my $util  = t::util->new({fixtures => 1, cgi => CGI->new() });
     model => npg::model::administration->new({ util => $util }),
     action => q{create},
     aspect => q{create_usergroup},
+    headers => HTTP::Headers->new()
   });
   $util->requestor('joe_admin');
   my $render;
@@ -173,6 +175,7 @@ my $util  = t::util->new({fixtures => 1, cgi => CGI->new() });
     model => npg::model::administration->new({ util => $util }),
     action => q{create},
     aspect => q{create_usergroup},
+    headers => HTTP::Headers->new()
   });
   eval { $render = $view->render(); };
   like($EVAL_ERROR, qr{No\ groupname\ and\/or\ group\ description\ given}, 'croaked - no description given');
@@ -184,6 +187,7 @@ my $util  = t::util->new({fixtures => 1, cgi => CGI->new() });
     model => npg::model::administration->new({ util => $util }),
     action => q{create},
     aspect => q{create_usergroup},
+    headers => HTTP::Headers->new()
   });
   eval { $render = $view->render(); };
   is($EVAL_ERROR, q{}, 'admin authorised for create_usergroup');
@@ -199,6 +203,7 @@ my $util  = t::util->new({fixtures => 1, cgi => CGI->new() });
     model => npg::model::administration->new({ util => $util }),
     action => q{create},
     aspect => q{create_entity_type},
+    headers => HTTP::Headers->new()
   });
   $util->requestor('joe_admin');
   my $render;
@@ -211,6 +216,7 @@ my $util  = t::util->new({fixtures => 1, cgi => CGI->new() });
     model => npg::model::administration->new({ util => $util }),
     action => q{create},
     aspect => q{create_entity_type},
+    headers => HTTP::Headers->new()
   });
   eval { $render = $view->render(); };
   is($EVAL_ERROR, q{}, 'admin authorised for create_entity_type');
@@ -225,6 +231,7 @@ my $util  = t::util->new({fixtures => 1, cgi => CGI->new() });
     model => npg::model::administration->new({ util => $util }),
     action => q{create},
     aspect => q{create_run_status},
+    headers => HTTP::Headers->new()
   });
   $util->requestor('joe_admin');
   my $render;
@@ -236,6 +243,7 @@ my $util  = t::util->new({fixtures => 1, cgi => CGI->new() });
     model => npg::model::administration->new({ util => $util }),
     action => q{create},
     aspect => q{create_run_status},
+    headers => HTTP::Headers->new()
   });
   eval { $render = $view->render(); };
   is($EVAL_ERROR, q{}, 'admin authorised for create_run_status');
@@ -249,11 +257,10 @@ my $util  = t::util->new({fixtures => 1, cgi => CGI->new() });
 
   my $view = npg::view::administration->new({
                util   => $util,
-               model  => npg::model::administration->new({
-                      util => $util,
-                           }),
+               model  => npg::model::administration->new({util => $util}),
                action => q{create},
                aspect => q{create_user_to_usergroup},
+               headers => HTTP::Headers->new()
               });
   $util->requestor('joe_admin');
 
@@ -267,6 +274,7 @@ my $util  = t::util->new({fixtures => 1, cgi => CGI->new() });
     model => npg::model::administration->new({ util => $util }),
     action => q{create},
     aspect => q{create_user_to_usergroup},
+    headers => HTTP::Headers->new()
   });
   eval { $render = $view->render(); };
   like($EVAL_ERROR, qr{No\ user\ and\/or\ usergroup\ given}, 'croaked - no usergroup given');
@@ -278,6 +286,7 @@ my $util  = t::util->new({fixtures => 1, cgi => CGI->new() });
     model => npg::model::administration->new({ util => $util }),
     action => q{create},
     aspect => q{create_user_to_usergroup},
+    headers => HTTP::Headers->new()
   });
   eval { $render = $view->render(); };
   is($EVAL_ERROR, q{}, 'admin authorised for create_usergroup');

--- a/t/20-view-instrument_mod.t
+++ b/t/20-view-instrument_mod.t
@@ -1,5 +1,6 @@
 use strict;
 use warnings;
+use HTTP::Headers;
 use Test::More tests => 17;
 use English qw(-no_match_vars);
 use t::util;
@@ -14,9 +15,8 @@ my $util = t::util->new({ fixtures => 1, cgi => CGI->new() });
                util   => $util,
                action => 'list',
                aspect => q{},
-               model  => npg::model::instrument_mod->new({
-                      util => $util,
-                           }),
+               model  => npg::model::instrument_mod->new({util => $util}),
+               headers => HTTP::Headers->new()
               });
   my $render;
   eval { $render = $view->render(); };
@@ -40,9 +40,8 @@ my $util = t::util->new({ fixtures => 1, cgi => CGI->new() });
                util   => $util,
                action => 'create',
                aspect => q{},
-               model  => npg::model::instrument_mod->new({
-                      util => $util,
-                           }),
+               model  => npg::model::instrument_mod->new({util => $util}),
+               headers => HTTP::Headers->new()
               });
   isa_ok($view, 'npg::view::instrument_mod');
   eval { $view->render(); };
@@ -70,9 +69,8 @@ my $util = t::util->new({ fixtures => 1, cgi => CGI->new() });
                util   => $util,
                action => 'create',
                aspect => q{},
-               model  => npg::model::instrument_mod->new({
-                      util => $util,
-                           }),
+               model  => npg::model::instrument_mod->new({util => $util}),
+               headers => HTTP::Headers->new()
               });
   eval { $view->render(); };
   is($EVAL_ERROR, q{}, 'engineers authorised for create');
@@ -100,9 +98,8 @@ $util = t::util->new({ fixtures => 1, cgi => CGI->new() });
                util   => $util,
                action => 'create',
                aspect => 'update_mods',
-               model  => npg::model::instrument_mod->new({
-                      util => $util,
-                           }),
+               model  => npg::model::instrument_mod->new({util => $util}),
+               headers => HTTP::Headers->new()
               });
   my $render = $view->render();
   is($EVAL_ERROR, qq{}, 'no croak on batch update of mods');


### PR DESCRIPTION
Failure in http://cpansearch.perl.org/src/RPETTETT/ClearPress-v475.1.20/lib/ClearPress/view.pm,  line 294
  if(!$self->authorised) {
    #########
    # set http forbidden response code
    #
    $self->headers->header('Status', HTTP_FORBIDDEN);

- new in release 475.1.20

If the request processing goes through its normal lifecycle, the headers object is set by the time the render() method is called on the view object. In tests the view objects are created directly. This fix creates the view objects with the headers attribute set. The above code change only affects the tests that test authorisation failure.

