### PR TITLE
Implement: determine aligner using ref genome string

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,9 @@
 LIST OF CHANGES
 
  - set explicit dist to precise in travis yml
+ - reference find role: when parsing a genome reference string return
+   the delimiter separating strain and transcriptome version along
+   with the organism
 
 release 86.4
  - reference find role: remove unused 'subset' attribute and

--- a/t/10-reference-find.t
+++ b/t/10-reference-find.t
@@ -1,6 +1,6 @@
 use strict;
 use warnings;
-use Test::More tests => 48;
+use Test::More tests => 49;
 use Test::Exception;
 use File::Spec::Functions qw(catfile);
 use Cwd qw(cwd);
@@ -192,12 +192,13 @@ use_ok('npg_tracking::data::reference::find');
 
 {
   my $ruser = Moose::Meta::Class->create_anon_class(
-      roles => [qw/npg_tracking::data::transcriptome::find/])
+      roles => [qw/npg_tracking::data::reference::find/])
       ->new_object({ repository => $transcriptome_repos });
-  is(join(q[ ],$ruser->parse_reference_genome(q[Homo_sapiens (1000Genomes_hs37d5 + ensembl_74_transcriptome)])),'Homo_sapiens 1000Genomes_hs37d5 ensembl_74_transcriptome','transcriptome ref genome parsing ok with correct format'); 
-  is(join(q[ ],$ruser->parse_reference_genome(q[Homo_sapiens (1000Genomes_hs37d5 ; ensembl_74_transcriptome)])),q[],'transcriptome ref genome parsing ok - returns empty with incorrect delimiter'); 
+  is(join(q[ ],$ruser->parse_reference_genome(q[Homo_sapiens (1000Genomes_hs37d5 + ensembl_74_transcriptome)])),'Homo_sapiens 1000Genomes_hs37d5 ensembl_74_transcriptome +','transcriptome ref genome parsing ok with correct format 1/2'); 
+  is(join(q[ ],$ruser->parse_reference_genome(q[Homo_sapiens (1000Genomes_hs37d5 * ensembl_74_transcriptome)])),'Homo_sapiens 1000Genomes_hs37d5 ensembl_74_transcriptome *','transcriptome ref genome parsing ok with correct format 2/2'); 
+  is(join(q[ ],$ruser->parse_reference_genome(q[Homo_sapiens (1000Genomes_hs37d5 + )])),q[Homo_sapiens 1000Genomes_hs37d5],'transcriptome ref genome parsing ok - returns genome and strain only with missing transcriptome version'); 
   is(join(q[ ],$ruser->parse_reference_genome(q[Homo_sapiens (1000Genomes_hs37d5 ensembl_74_transcriptome)])),q[],'transcriptome ref genome parsing ok - returns empty with missing delimiter'); 
-  is(join(q[ ],$ruser->parse_reference_genome(q[Homo_sapiens (1000Genomes_hs37d5 + ensembl_74_transcriptome])),q[],'transcriptome ref genome parsing ok - returns empty with missing bracket'); 
+  is(join(q[ ],$ruser->parse_reference_genome(q[Homo_sapiens (1000Genomes_hs37d5 + ensembl_74_transcriptome])),q[],'transcriptome ref genome parsing ok - returns empty with missing bracket');
 
   $ruser = Moose::Meta::Class->create_anon_class(
           roles => [qw/npg_tracking::data::reference::find/])


### PR DESCRIPTION
- reference find role: when parsing a reference genome string return
  the delimiter separating strain and transcriptome version so it
  can be used to determine an aligner e.g. seq_alignment
- new test cases in reference find role testing module
- update changelog