### PR TITLE
pick analysis using ref genome string

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,9 +2,9 @@ LIST OF CHANGES
 
  - remove unused classes for image generation
  - set explicit dist to precise in travis yml
- - reference find role: when parsing a genome reference string return
-   the delimiter separating strain and transcriptome version along
-   with the organism
+ - reference find role: when parsing a genome reference string 
+   return the aligner, along with the organism, strain
+   and transcriptome version, if present
 
 release 86.4
  - reference find role: remove unused 'subset' attribute and

--- a/Changes
+++ b/Changes
@@ -2,6 +2,9 @@ LIST OF CHANGES
 
  - remove unused classes for image generation
  - set explicit dist to precise in travis yml
+ - reference find role: when parsing a genome reference string return
+   the delimiter separating strain and transcriptome version along
+   with the organism
 
 release 86.4
  - reference find role: remove unused 'subset' attribute and

--- a/Changes
+++ b/Changes
@@ -3,8 +3,10 @@ LIST OF CHANGES
  - remove unused classes for image generation
  - set explicit dist to precise in travis yml
  - reference find role: when parsing a genome reference string 
-   return the aligner, along with the organism, strain
+   return the analysis, along with the organism, strain
    and transcriptome version, if present
+ - refactor transcriptome::find to improve code reuse and add
+   new find file/path/index attributes and functionalities
 
 release 86.4
  - reference find role: remove unused 'subset' attribute and

--- a/lib/npg_tracking/data/reference/find.pm
+++ b/lib/npg_tracking/data/reference/find.pm
@@ -372,7 +372,7 @@ sub parse_reference_genome {
     my ($self, $reference_genome) = @_;
     $reference_genome ||= $self->reference_genome;
     if ($reference_genome) {
-        my ($organism, $strain, $tversion, $analysis, $parsed, @array);
+        my ($organism, $strain, $tversion, $analysis, @array);
         ## allows for transcriptome version and analysis e.g. 'Homo_sapiens (1000Genomes_hs37d5 + ensembl_release_75) [star]'
         $organism = '(?<organism>\S+)\s+';
         $strain = '(?<strain>\S+)';

--- a/lib/npg_tracking/data/reference/find.pm
+++ b/lib/npg_tracking/data/reference/find.pm
@@ -18,7 +18,6 @@ our $VERSION = '0';
 
 Readonly::Scalar our $NPG_DEFAULT_ALIGNER_OPTION => q{npg_default};
 Readonly::Scalar our $MINUS_ONE                  => -1;
-Readonly::Scalar our $THREE                      => 3;
 
 =head1 NAME
 
@@ -379,7 +378,7 @@ sub parse_reference_genome {
         $strain = '(?<strain>\S+)';
         $tversion = '(?:\s+\+\s+(?<tversion>\S+))?';
         $analysis = '(?:\s+[[](?<analysis>\S+)[]])?';
-        $parsed = $reference_genome  =~ qr{$organism [(] $strain $tversion [)] $analysis}smx;
+        $reference_genome  =~ qr{$organism [(] $strain $tversion [)] $analysis}smx;
         $organism = $LAST_PAREN_MATCH{'organism'};
         $strain = $LAST_PAREN_MATCH{'strain'};
         $tversion = $LAST_PAREN_MATCH{'tversion'};

--- a/lib/npg_tracking/data/reference/find.pm
+++ b/lib/npg_tracking/data/reference/find.pm
@@ -380,10 +380,10 @@ sub parse_reference_genome {
         $tversion = '(?:\s+\+\s+(?<tversion>\S+))?';
         $analysis = '(?:\s+[[](?<analysis>\S+)[]])?';
         $parsed = $reference_genome  =~ qr{$organism [(] $strain $tversion [)] $analysis}smx;
-        $organism = $LAST_PAREN_MATCH{organism};
-        $strain = $LAST_PAREN_MATCH{strain};
-        $tversion = $LAST_PAREN_MATCH{tversion};
-        $analysis = $LAST_PAREN_MATCH{analysis};
+        $organism = $LAST_PAREN_MATCH{'organism'};
+        $strain = $LAST_PAREN_MATCH{'strain'};
+        $tversion = $LAST_PAREN_MATCH{'tversion'};
+        $analysis = $LAST_PAREN_MATCH{'analysis'};
         if ($organism && $strain) {
             if ($tversion || $analysis) {
                 @array = ($organism, $strain, $tversion, $analysis);

--- a/lib/npg_tracking/data/transcriptome.pm
+++ b/lib/npg_tracking/data/transcriptome.pm
@@ -5,14 +5,8 @@ use Readonly;
 
 our $VERSION = '0';
 
-Readonly::Scalar our $DEFAULT_ANALYSIS => q[tophat2];
-
 extends 'npg_tracking::data::reference';
 with    'npg_tracking::data::transcriptome::find';
-
-has 'analysis' => (default  => $DEFAULT_ANALYSIS,
-                   is       => 'ro',
-                   required => 0,);
 
 __PACKAGE__->meta->make_immutable;
 
@@ -42,10 +36,6 @@ A wrapper class for finding the location of transcriptome files.
 =head2 tag_index
 
 =head2 rpt_list
-
-=head2 analysis
-
-An optional attribute used to find the path and files of transcriptome indices
 
 =head1 DIAGNOSTICS
 

--- a/lib/npg_tracking/data/transcriptome.pm
+++ b/lib/npg_tracking/data/transcriptome.pm
@@ -1,7 +1,6 @@
 package npg_tracking::data::transcriptome;
 
 use Moose;
-use Readonly;
 
 our $VERSION = '0';
 
@@ -46,8 +45,6 @@ A wrapper class for finding the location of transcriptome files.
 =over
 
 =item Moose
-
-=item Readonly
 
 =back
 

--- a/lib/npg_tracking/data/transcriptome.pm
+++ b/lib/npg_tracking/data/transcriptome.pm
@@ -1,13 +1,21 @@
 package npg_tracking::data::transcriptome;
 
 use Moose;
+use Readonly;
 
 our $VERSION = '0';
+
+Readonly::Scalar our $DEFAULT_ANALYSIS => q[tophat2];
 
 extends 'npg_tracking::data::reference';
 with    'npg_tracking::data::transcriptome::find';
 
+has 'analysis' => (default  => $DEFAULT_ANALYSIS,
+                   is       => 'ro',
+                   required => 0,);
+
 __PACKAGE__->meta->make_immutable;
+
 no Moose;
 
 1;
@@ -35,6 +43,10 @@ A wrapper class for finding the location of transcriptome files.
 
 =head2 rpt_list
 
+=head2 analysis
+
+An optional attribute used to find the path and files of transcriptome indices
+
 =head1 DIAGNOSTICS
 
 =head1 CONFIGURATION AND ENVIRONMENT
@@ -44,6 +56,8 @@ A wrapper class for finding the location of transcriptome files.
 =over
 
 =item Moose
+
+=item Readonly
 
 =back
 

--- a/lib/npg_tracking/data/transcriptome/find.pm
+++ b/lib/npg_tracking/data/transcriptome/find.pm
@@ -4,15 +4,15 @@ use Moose::Role;
 use Carp;
 use npg_tracking::util::abs_path qw(abs_path);
 
+Readonly::Scalar our $DEFAULT_ANALYSIS => q[tophat2];
 Readonly::Hash our %ANALYSES => ('tophat2' => { 'ext'  => 'bt2' },
-                                 'salmon'  => { 'ext'  => 'json' },
-                                 'default' => 'tophat2',);
+                                 'salmon'  => { 'ext'  => 'json' },);
 
 with qw/ npg_tracking::data::reference::find /;
 
 our $VERSION = '0';
 
-has 'analysis' => (default  => $ANALYSES{q{default}},
+has 'analysis' => (default  => $DEFAULT_ANALYSIS,
                    is       => 'ro',
                    required => 0,);
 

--- a/t/10-reference-find.t
+++ b/t/10-reference-find.t
@@ -1,6 +1,6 @@
 use strict;
 use warnings;
-use Test::More tests => 51;
+use Test::More tests => 52;
 use Test::Exception;
 use File::Spec::Functions qw(catfile);
 use Cwd qw(cwd);
@@ -191,12 +191,14 @@ use_ok('npg_tracking::data::reference::find');
 }
 
 {
+  no warnings 'uninitialized';
   my $ruser = Moose::Meta::Class->create_anon_class(
       roles => [qw/npg_tracking::data::reference::find/])
       ->new_object({ repository => $transcriptome_repos });
   is(join(q[|],$ruser->parse_reference_genome(q[Homo_sapiens (1000Genomes_hs37d5 + ensembl_74_transcriptome)])),'Homo_sapiens|1000Genomes_hs37d5|ensembl_74_transcriptome|','transcriptome ref genome parsing ok with correct format');
   is(join(q[|],$ruser->parse_reference_genome(q[Homo_sapiens (1000Genomes_hs37d5 + ensembl_74_transcriptome) [star]])),'Homo_sapiens|1000Genomes_hs37d5|ensembl_74_transcriptome|star','transcriptome ref genome parsing ok with aligner 1/2');
   is(join(q[|],$ruser->parse_reference_genome(q[Homo_sapiens (1000Genomes_hs37d5) [star]])),q[Homo_sapiens|1000Genomes_hs37d5||star],'transcriptome ref genome parsing ok with aligner 2/2');
+  is(join(q[|],$ruser->parse_reference_genome(q[Homo_sapiens (1000Genomes_hs37d5)])),q[Homo_sapiens|1000Genomes_hs37d5],'transcriptome ref genome parsing ok without aligner');
   is(join(q[|],$ruser->parse_reference_genome(q[Homo_sapiens (1000Genomes_hs37d5 + )])), q[],'transcriptome ref genome parsing ok - returns empty with missing transcriptome version');
   is(join(q[|],$ruser->parse_reference_genome(q[Homo_sapiens (1000Genomes_hs37d5 ensembl_74_transcriptome)])),q[],'transcriptome ref genome parsing ok - returns empty with missing delimiter');
   is(join(q[|],$ruser->parse_reference_genome(q[Homo_sapiens (1000Genomes_hs37d5 + ensembl_74_transcriptome])),q[],'transcriptome ref genome parsing ok - returns empty with missing bracket');

--- a/t/10-reference-find.t
+++ b/t/10-reference-find.t
@@ -1,6 +1,6 @@
 use strict;
 use warnings;
-use Test::More tests => 48;
+use Test::More tests => 49;
 use Test::Exception;
 use File::Spec::Functions qw(catfile);
 use Cwd qw(cwd);
@@ -192,12 +192,13 @@ use_ok('npg_tracking::data::reference::find');
 
 {
   my $ruser = Moose::Meta::Class->create_anon_class(
-      roles => [qw/npg_tracking::data::transcriptome::find/])
+      roles => [qw/npg_tracking::data::reference::find/])
       ->new_object({ repository => $transcriptome_repos });
-  is(join(q[ ],$ruser->parse_reference_genome(q[Homo_sapiens (1000Genomes_hs37d5 + ensembl_74_transcriptome)])),'Homo_sapiens 1000Genomes_hs37d5 ensembl_74_transcriptome','transcriptome ref genome parsing ok with correct format'); 
-  is(join(q[ ],$ruser->parse_reference_genome(q[Homo_sapiens (1000Genomes_hs37d5 ; ensembl_74_transcriptome)])),q[],'transcriptome ref genome parsing ok - returns empty with incorrect delimiter'); 
+  is(join(q[ ],$ruser->parse_reference_genome(q[Homo_sapiens (1000Genomes_hs37d5 + ensembl_74_transcriptome)])),'Homo_sapiens 1000Genomes_hs37d5 ensembl_74_transcriptome +','transcriptome ref genome parsing ok with correct format 1/2'); 
+  is(join(q[ ],$ruser->parse_reference_genome(q[Homo_sapiens (1000Genomes_hs37d5 * ensembl_74_transcriptome)])),'Homo_sapiens 1000Genomes_hs37d5 ensembl_74_transcriptome *','transcriptome ref genome parsing ok with correct format 2/2'); 
+  is(join(q[ ],$ruser->parse_reference_genome(q[Homo_sapiens (1000Genomes_hs37d5 + )])),q[Homo_sapiens 1000Genomes_hs37d5],'transcriptome ref genome parsing ok - returns genome and strain only with missing transcriptome version'); 
   is(join(q[ ],$ruser->parse_reference_genome(q[Homo_sapiens (1000Genomes_hs37d5 ensembl_74_transcriptome)])),q[],'transcriptome ref genome parsing ok - returns empty with missing delimiter'); 
-  is(join(q[ ],$ruser->parse_reference_genome(q[Homo_sapiens (1000Genomes_hs37d5 + ensembl_74_transcriptome])),q[],'transcriptome ref genome parsing ok - returns empty with missing bracket'); 
+  is(join(q[ ],$ruser->parse_reference_genome(q[Homo_sapiens (1000Genomes_hs37d5 + ensembl_74_transcriptome])),q[],'transcriptome ref genome parsing ok - returns empty with missing bracket');
 
   $ruser = Moose::Meta::Class->create_anon_class(
           roles => [qw/npg_tracking::data::reference::find/])

--- a/t/10-reference-find.t
+++ b/t/10-reference-find.t
@@ -1,6 +1,6 @@
 use strict;
 use warnings;
-use Test::More tests => 49;
+use Test::More tests => 51;
 use Test::Exception;
 use File::Spec::Functions qw(catfile);
 use Cwd qw(cwd);
@@ -194,11 +194,13 @@ use_ok('npg_tracking::data::reference::find');
   my $ruser = Moose::Meta::Class->create_anon_class(
       roles => [qw/npg_tracking::data::reference::find/])
       ->new_object({ repository => $transcriptome_repos });
-  is(join(q[ ],$ruser->parse_reference_genome(q[Homo_sapiens (1000Genomes_hs37d5 + ensembl_74_transcriptome)])),'Homo_sapiens 1000Genomes_hs37d5 ensembl_74_transcriptome +','transcriptome ref genome parsing ok with correct format 1/2'); 
-  is(join(q[ ],$ruser->parse_reference_genome(q[Homo_sapiens (1000Genomes_hs37d5 * ensembl_74_transcriptome)])),'Homo_sapiens 1000Genomes_hs37d5 ensembl_74_transcriptome *','transcriptome ref genome parsing ok with correct format 2/2'); 
-  is(join(q[ ],$ruser->parse_reference_genome(q[Homo_sapiens (1000Genomes_hs37d5 + )])),q[Homo_sapiens 1000Genomes_hs37d5],'transcriptome ref genome parsing ok - returns genome and strain only with missing transcriptome version'); 
-  is(join(q[ ],$ruser->parse_reference_genome(q[Homo_sapiens (1000Genomes_hs37d5 ensembl_74_transcriptome)])),q[],'transcriptome ref genome parsing ok - returns empty with missing delimiter'); 
-  is(join(q[ ],$ruser->parse_reference_genome(q[Homo_sapiens (1000Genomes_hs37d5 + ensembl_74_transcriptome])),q[],'transcriptome ref genome parsing ok - returns empty with missing bracket');
+  is(join(q[|],$ruser->parse_reference_genome(q[Homo_sapiens (1000Genomes_hs37d5 + ensembl_74_transcriptome)])),'Homo_sapiens|1000Genomes_hs37d5|ensembl_74_transcriptome|','transcriptome ref genome parsing ok with correct format');
+  is(join(q[|],$ruser->parse_reference_genome(q[Homo_sapiens (1000Genomes_hs37d5 + ensembl_74_transcriptome) [star]])),'Homo_sapiens|1000Genomes_hs37d5|ensembl_74_transcriptome|star','transcriptome ref genome parsing ok with aligner 1/2');
+  is(join(q[|],$ruser->parse_reference_genome(q[Homo_sapiens (1000Genomes_hs37d5) [star]])),q[Homo_sapiens|1000Genomes_hs37d5||star],'transcriptome ref genome parsing ok with aligner 2/2');
+  is(join(q[|],$ruser->parse_reference_genome(q[Homo_sapiens (1000Genomes_hs37d5 + )])), q[],'transcriptome ref genome parsing ok - returns empty with missing transcriptome version');
+  is(join(q[|],$ruser->parse_reference_genome(q[Homo_sapiens (1000Genomes_hs37d5 ensembl_74_transcriptome)])),q[],'transcriptome ref genome parsing ok - returns empty with missing delimiter');
+  is(join(q[|],$ruser->parse_reference_genome(q[Homo_sapiens (1000Genomes_hs37d5 + ensembl_74_transcriptome])),q[],'transcriptome ref genome parsing ok - returns empty with missing bracket');
+  is(join(q[|],$ruser->parse_reference_genome(q(Homo_sapiens (1000Genomes_hs37d5 + ensembl_74_transcriptome) [star))),'Homo_sapiens|1000Genomes_hs37d5|ensembl_74_transcriptome|','transcriptome ref genome parsing ok - aligner ignored with missing square bracket');
 
   $ruser = Moose::Meta::Class->create_anon_class(
           roles => [qw/npg_tracking::data::reference::find/])

--- a/t/10-transcriptome.t
+++ b/t/10-transcriptome.t
@@ -189,7 +189,7 @@ throws_ok { $test6->gtf_file } qr/More than one gtf file/,
 'ok - croaks when more than 1 gtf file found - Mus_musculus (GRCm38 + ensembl_84_transcriptome)';
 
 my $prefix_path_84 = catfile($tmp_repos, q[transcriptomes/Mus_musculus/ensembl_84_transcriptome/GRCm38/tophat2/GRCm38.known]);
-my $re_no_idx_name = qr/^Directory.*exists.*index.*files.*not.*found$/msxi;
+my $re_no_idx_name = qr/^Directory.*exists.*index.*files.*not.*found.*$/msxi;
 my $empty_idx_name = $test6->transcriptome_index_name;
 lives_and { is $empty_idx_name, undef } "ok - returns undef for transcriptome_index_name if index files are not present - Mus_musculus (GRCm38 + ensembl_84_transcriptome)";
 my ($tmsg, $msg);

--- a/t/10-transcriptome.t
+++ b/t/10-transcriptome.t
@@ -5,7 +5,7 @@ package transcriptome;
 
 use strict;
 use warnings;
-use Test::More tests => 9;
+use Test::More tests => 15;
 use File::Basename;
 use File::Spec::Functions qw(catfile);
 use Test::Exception;
@@ -37,16 +37,21 @@ foreach my $spp (keys %builds){
         
         my $rel_dir1 = join q[/],$dir,$spp,'ensembl_75_transcriptome';
         my $rel_dir2 = join q[/],$dir,$spp,'ensembl_74_transcriptome';
+        my $rel_dir3 = join q[/],$dir,$spp,'ensembl_84_transcriptome';
 
-        foreach my $rel_dir ($rel_dir1,$rel_dir2){
+        foreach my $rel_dir ($rel_dir1,$rel_dir2,$rel_dir3){
         
           foreach my $build (@{ $builds{$spp} }){
             my $gtf_dir    = join q[/],$rel_dir,$build,'gtf'; 
             my $rnaseq_dir = join q[/],$rel_dir,$build,'RNA-SeQC';
             my $tophat_dir = join q[/],$rel_dir,$build,'tophat2';
+            my $salmon_dir = join q[/],$rel_dir,$build,'salmon';
+            my $fasta_dir  = join q[/],$rel_dir,$build,'fasta';
             make_path($gtf_dir,
                       $rnaseq_dir,
                       $tophat_dir,
+                      $salmon_dir,
+                      $fasta_dir,
                       {verbose => 0});
           }
         }
@@ -82,7 +87,19 @@ foreach my $v ('ensembl_74_transcriptome','ensembl_75_transcriptome'){
         push @files, join(q[/], $vdir,'RNA-SeQC',$v . '-1000Genomes_hs37d5.gtf');
         push @files, join(q[/], $vdir,'tophat2','1000Genomes_hs37d5.known.1.bt2');
         push @files, join(q[/], $vdir,'tophat2','1000Genomes_hs37d5.known.ver');
-        
+        push @files, join(q[/], $vdir,'salmon','versionInfo.json');
+        push @files, join(q[/], $vdir,'salmon','refInfo.json');
+        push @files, join(q[/], $vdir,'salmon','header.json');
+        push @files, join(q[/], $vdir,'fasta','1000Genomes_hs37d5.fa');
+}
+
+#make directory structure with empty files and funny business (multiple files, missing files, etc)
+foreach my $v ('ensembl_84_transcriptome'){
+        my $vdir = join(q[/], $dir, 'Mus_musculus',$v, 'GRCm38',);
+        #more than 1 gtf present
+        push @files, join(q[/], $vdir,'gtf',$v . '-GRCm38.gtf');
+        push @files, join(q[/], $vdir,'gtf', 'GRCm38_sans_mt.gtf');
+        #the rest of the instances are missing
 }
 
 foreach my $file (@files){
@@ -141,6 +158,44 @@ lives_and { is $test3->transcriptome_index_path, catfile($tmp_repos, q[transcrip
 
 my $prefix_path_74 = catfile($tmp_repos, q[transcriptomes/Homo_sapiens/ensembl_74_transcriptome/1000Genomes_hs37d5/tophat2/1000Genomes_hs37d5.known]);
 lives_and { is $test3->transcriptome_index_name, $prefix_path_74 } "Correctly found transcriptome version index name path and prefix ";
+
+my $test4 = npg_tracking::data::transcriptome->new (id_run => 12161, position => 1, tag_index => 1, repository => $tmp_repos, aligner => 'tophat2', analysis => 'salmon');
+lives_and { is $test4->transcriptome_index_path, catfile($tmp_repos, q[transcriptomes/Homo_sapiens/ensembl_74_transcriptome/1000Genomes_hs37d5/salmon])
+} "correct path for salmon indices found";
+
+lives_and { is $test4->transcriptome_index_name, undef
+} "ok - returns undef when looking for index name for salmon";
+
+my $test5 = npg_tracking::data::transcriptome->new (id_run => 12161, position => 1, tag_index => 1, repository => $tmp_repos);
+lives_and { is basename($test5->fasta_file), '1000Genomes_hs37d5.fa'
+} "transcriptome fasta file 1000Genomes_hs37d5.fa found where reference = Homo_sapiens (1000Genomes_hs37d5 + ensembl_74_transcriptome)";
+
+
+##update sample xml so that Reference Genome has a transcriptome version : Mus_musculus (GRCm38 + ensembl_84_transcriptome)
+copy("$tmp_repos/$samples_dir/1807468.xml", "$tmp_repos/$samples_dir/1807468.xml.1") or carp "Copy failed: $!";
+my $cpy_fh = IO::File->new("<$tmp_repos/$samples_dir/1807468.xml.1") or carp "cannot open $repos/$samples_dir/1807468.xml.1";
+my $mm_ver_fh = IO::File->new(">$tmp_repos/$samples_dir/1807468.xml") or carp "cannot open $repos/$samples_dir/1807468.xml";
+while(<$cpy_fh>){
+    if (/Mus_musculus\s+(\S+)/){
+        print $mm_ver_fh " " x 6 . "<value>Mus_musculus (GRCm38 + ensembl_84_transcriptome)</value>\n";
+    }
+    else { print $mm_ver_fh $_ }
+}
+$mm_ver_fh->close;
+$cpy_fh->close;
+
+my $test6 = npg_tracking::data::transcriptome->new (id_run => 12071, position => 4, tag_index => 2, repository => $tmp_repos);
+throws_ok { $test6->gtf_file } qr/More than one gtf file/,
+'ok - croaks when more than 1 gtf file found - Mus_musculus (GRCm38 + ensembl_84_transcriptome)';
+
+my $prefix_path_84 = catfile($tmp_repos, q[transcriptomes/Mus_musculus/ensembl_84_transcriptome/GRCm38/tophat2/GRCm38.known]);
+my $re_no_idx_name = qr/^Directory.*exists.*index.*files.*not.*found$/msxi;
+my $empty_idx_name = $test6->transcriptome_index_name;
+lives_and { is $empty_idx_name, undef } "ok - returns undef for transcriptome_index_name if index files are not present - Mus_musculus (GRCm38 + ensembl_84_transcriptome)";
+my ($tmsg, $msg);
+$tmsg = $test6->messages()->mlist;
+foreach my $m (@{$tmsg}){ $msg = $m; last if ($msg =~ /$re_no_idx_name/); }
+like($msg, $re_no_idx_name, 'ok - message stored when index files not found');
 
 }
 


### PR DESCRIPTION
Return aligner when parsing reference genome string
- This is a completely different approach from previous commit but the aim is the same: parse the _analysis_ name expected to be at the end of the reference genome string, between '[]', and even if there is no transcriptome version present (so not only for RNA-Seq)
- Change is compatible with current usage of the find() method in reference module
- Test module was changed to add new parsing scenarios
- Update the changelog accordingly