### PR TITLE
Add method to find file with globin genes inside transcriptome repo

### DIFF
--- a/lib/npg_tracking/data/transcriptome/find.pm
+++ b/lib/npg_tracking/data/transcriptome/find.pm
@@ -14,7 +14,8 @@ our $VERSION = '0';
 
 has 'analysis' => (default  => $DEFAULT_ANALYSIS,
                    is       => 'ro',
-                   required => 0,);
+                   required => 0,
+                  );
 
 has '_organism_dir' => ( isa        => q{Maybe[Str]},
                          is         => q{ro},
@@ -111,6 +112,30 @@ has 'gtf_file' => ( isa           => q{Maybe[Str]},
 sub _build_gtf_file {
   my $self = shift;
   return $self->_find_file('gtf', 'gtf');
+}
+
+has 'globin_path' => (isa           => q{Maybe[Str]},
+                     is            => q{ro},
+                     lazy          => 1,
+                     builder       => q{_build_globin_path},
+                     documentation => 'Path to directory of file with list of globin genes',
+                    );
+
+sub _build_globin_path {
+    my $self = shift;
+    return $self->_find_path('globin');
+}
+
+has 'globin_file' => (isa           => q{Maybe[Str]},
+                     is            => q{ro},
+                     lazy          => 1,
+                     builder       => q{_build_globin_file},
+                     documentation => 'Full name of transcriptome fasta file',
+                    );
+
+sub _build_globin_file {
+  my $self = shift;
+  return $self->_find_file('globin', 'csv');
 }
 
 #transcriptomes/Homo_sapiens/ensembl_75_transcriptome/1000Genomes_hs37d5/{tophat2,salmon}/

--- a/t/10-transcriptome.t
+++ b/t/10-transcriptome.t
@@ -5,7 +5,7 @@ package transcriptome;
 
 use strict;
 use warnings;
-use Test::More tests => 15;
+use Test::More tests => 16;
 use File::Basename;
 use File::Spec::Functions qw(catfile);
 use Test::Exception;
@@ -47,11 +47,13 @@ foreach my $spp (keys %builds){
             my $tophat_dir = join q[/],$rel_dir,$build,'tophat2';
             my $salmon_dir = join q[/],$rel_dir,$build,'salmon';
             my $fasta_dir  = join q[/],$rel_dir,$build,'fasta';
+            my $globin_dir  = join q[/],$rel_dir,$build,'globin';
             make_path($gtf_dir,
                       $rnaseq_dir,
                       $tophat_dir,
                       $salmon_dir,
                       $fasta_dir,
+                      $globin_dir,
                       {verbose => 0});
           }
         }
@@ -91,6 +93,7 @@ foreach my $v ('ensembl_74_transcriptome','ensembl_75_transcriptome'){
         push @files, join(q[/], $vdir,'salmon','refInfo.json');
         push @files, join(q[/], $vdir,'salmon','header.json');
         push @files, join(q[/], $vdir,'fasta','1000Genomes_hs37d5.fa');
+        push @files, join(q[/], $vdir,'globin','globin_genes.csv');
 }
 
 #make directory structure with empty files and funny business (multiple files, missing files, etc)
@@ -155,6 +158,8 @@ lives_and { is basename($test3->rnaseqc_gtf_file), 'ensembl_74_transcriptome-100
 
 lives_and { is $test3->transcriptome_index_path, catfile($tmp_repos, q[transcriptomes/Homo_sapiens/ensembl_74_transcriptome/1000Genomes_hs37d5/tophat2])
 } "correct path for bowtie2 indices found";
+
+lives_and { is basename($test3->globin_file), 'globin_genes.csv' } 'globin genes csv file found where reference = Homo_sapiens (1000Genomes_hs37d5 + ensembl_74_transcriptome)';
 
 my $prefix_path_74 = catfile($tmp_repos, q[transcriptomes/Homo_sapiens/ensembl_74_transcriptome/1000Genomes_hs37d5/tophat2/1000Genomes_hs37d5.known]);
 lives_and { is $test3->transcriptome_index_name, $prefix_path_74 } "Correctly found transcriptome version index name path and prefix ";


### PR DESCRIPTION
This method is used by the RNA-SeQC check which uses the file to estimate the globin genes contents in a bam file 