### PR TITLE
limit num instrument statuses displayed

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,10 @@
 LIST OF CHANGES
 
+ - the bug in paged run views where a particular instrument was selected
+     is fixed
+ - the frame hight for displaying runs on an instrument page is increased
+ - displayed instrument statuses in the instrument view are limited
+     to most recent (created within a year from the current date)
  - npg_tracking::illumina::runfolder is simplified at a cost of loosing
    ability to pass to the constructor an arbitrary path
  - npg_tracking::illumina::run::short_info role - added database

--- a/data/templates/instrument_read.tt2
+++ b/data/templates/instrument_read.tt2
@@ -81,6 +81,7 @@ END -%]
         [% annotation.comment %] ( [% annotation.user.username %]-[% annotation.date %])<br/>
      [% END %]
    </td>
+   [% PROCESS instrument_status_annotation.tt2 %]
   </tr>[% END %]
  </tbody>
 </table>

--- a/data/templates/instrument_read.tt2
+++ b/data/templates/instrument_read.tt2
@@ -70,7 +70,7 @@ END -%]
  </thead>
  <tbody>
 [% PROCESS instrument_status_add.tt2 %]
-[% FOREACH instrument_status = model.instrument_statuses %]
+[% FOREACH instrument_status = model.recent_instrument_statuses %]
   <tr>
    <td>[% instrument_status.date %]</td>
    <td>[% instrument_status.description %]</td>
@@ -81,7 +81,6 @@ END -%]
         [% annotation.comment %] ( [% annotation.user.username %]-[% annotation.date %])<br/>
      [% END %]
    </td>
-   [% PROCESS instrument_status_annotation.tt2 %]
   </tr>[% END %]
  </tbody>
 </table>
@@ -145,7 +144,7 @@ END -%]
 </div>
 
 <div id="selector_runs" style="display:none">
-<iframe width="100%" name="runs_on_instrument" height="300px" frameborder="0"  src="[% SCRIPT_NAME %]/run/?id_run_status_dict=all&id_instrument=[% model.id_instrument %]"></iframe>
+<iframe width="100%" name="runs_on_instrument" height="400px" frameborder="0"  src="[% SCRIPT_NAME %]/run/?id_run_status_dict=all&id_instrument=[% model.id_instrument %]"></iframe>
 </div>
 
 </div>

--- a/data/templates/run_list.tt2
+++ b/data/templates/run_list.tt2
@@ -26,7 +26,7 @@
 <span class="medium_header ">Page: </span>
 [% i = 0 %]
 [% WHILE i * model.len < model.count_runs %]
-&middot;<a [% target %][% IF i == model.start / model.len%]class="active" [% END %] href="[% SCRIPT_NAME %]/[% model.table %][% IF model.id_instrument %]/[% model.id_instrument %][% END %]?id_run_status_dict=[% model.id_run_status_dict %]&len=[% model.len %]&start=[% i * model.len %]&id_instrument_format=[% model.id_instrument_format %]&id_instrument=[% id_instrument %]" id="pagination_[% i+1 %]">[% i+1 %]</a>&middot;
+&middot;<a [% target %][% IF i == model.start / model.len%]class="active" [% END %] href="[% SCRIPT_NAME %]/[% model.table %]?id_run_status_dict=[% model.id_run_status_dict %]&len=[% model.len %]&start=[% i * model.len %]&id_instrument_format=[% model.id_instrument_format %]&id_instrument=[% id_instrument %]" id="pagination_[% i+1 %]">[% i+1 %]</a>&middot;
 [% i = i + 1 %]
 [% END %]
 </div>

--- a/t/10-model-instrument.t
+++ b/t/10-model-instrument.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings;
 use t::util;
-use Test::More tests => 119;
+use Test::More tests => 125;
 use Test::Deep;
 use Test::Exception;
 
@@ -380,6 +380,26 @@ lives_ok {$util->fixtures_path(q[t/data/fixtures]); $util->load_fixtures;} 'a fr
   is(join(q[,], @{$model->possible_next_statuses4status('wash in progress')}),
     'wash performed,planned repair,planned service,down for repair', 
     'possible_next_statuses for "wash in progress" called as an object method');
+}
+
+{
+  my $model = npg::model::instrument->new({
+             util          => $util,
+             id_instrument => 4,
+            });
+  my $recent_is = $model->recent_instrument_statuses();
+  isa_ok($recent_is, 'ARRAY');
+  ok (!@{$recent_is}, 'no statuses within last year');
+  is( scalar @{$model->instrument_statuses()}, 2, 'two statuses in total');
+
+  lives_ok { $model->status_reset('wash required') } 'new status added';
+
+  $model = npg::model::instrument->new({
+             util          => $util,
+             id_instrument => 4,
+            });
+  is( scalar @{$model->recent_instrument_statuses()}, 1, 'one recent status');
+  is (scalar @{$model->instrument_statuses()}, 3, 'number of statuses in total');
 }
 
 1;

--- a/t/20-view-instrument.t
+++ b/t/20-view-instrument.t
@@ -6,6 +6,7 @@ use t::util;
 use t::request;
 use GD qw(:DEFAULT :cmp);
 use File::Spec;
+use DateTime();
 
 use_ok('npg::view::instrument');
 
@@ -67,6 +68,13 @@ my $image_dir = File::Spec->catfile('t', 'data', 'rendered', 'images');
 }
 
 {
+  my $now = DateTime->now() . q[];
+  my $sql = "update instrument_status set date='$now'";
+  if (!$util->dbh->do($sql)) {
+    die 'Failed to update date';
+  }
+  $util->dbh->commit();
+
   my $str = t::request->new({
            REQUEST_METHOD => 'GET',
            PATH_INFO      => '/instrument/11',

--- a/t/data/rendered/instrument/11.html
+++ b/t/data/rendered/instrument/11.html
@@ -39,6 +39,14 @@
    </tr>
   </thead>
   <tbody>
+   <tr>
+    <td>2007-10-02 11:02:52</td>
+    <td>up</td>
+    <td>joe_admin</td>
+    <td>networked </td>
+    <td>
+    </td>
+   </tr>
   </tbody>
  </table>
  </div>

--- a/t/data/rendered/instrument/11.html
+++ b/t/data/rendered/instrument/11.html
@@ -39,14 +39,6 @@
    </tr>
   </thead>
   <tbody>
-   <tr>
-    <td>2007-10-02 11:02:52</td>
-    <td>up</td>
-    <td>joe_admin</td>
-    <td>networked </td>
-    <td>
-    </td>
-   </tr>
   </tbody>
  </table>
  </div>
@@ -86,7 +78,7 @@
  </div>
  
  <div id="selector_runs" style="display:none">
- <iframe width="100%" name="runs_on_instrument" height="300px" frameborder="0"  src="/cgi-bin/npg/run/?id_run_status_dict=all&id_instrument=11"></iframe>
+ <iframe width="100%" name="runs_on_instrument" height="400px" frameborder="0"  src="/cgi-bin/npg/run/?id_run_status_dict=all&id_instrument=11"></iframe>
  </div>
  </div>
  </div>

--- a/t/data/rendered/run/runs_on_instrument.html
+++ b/t/data/rendered/run/runs_on_instrument.html
@@ -7,7 +7,7 @@
  
  <div class="smaller_font_85">
  <span class="medium_header ">Page: </span>
- &middot;<a target="runs_on_instrument" class="active"  href="/cgi-bin/npg/run/3?id_run_status_dict=all&len=40&start=0&id_instrument_format=all&id_instrument=3" id="pagination_1" >1</a>&middot;
+ &middot;<a target="runs_on_instrument" class="active"  href="/cgi-bin/npg/run?id_run_status_dict=all&len=40&start=0&id_instrument_format=all&id_instrument=3" id="pagination_1" >1</a>&middot;
  </div>
  </div>
  <table id="runs" class="sortable zebra">


### PR DESCRIPTION
 ... and fix run listing for an instrument.

Customer complained about slow loading of the instrumemt page due to a large numebr of instrument statuses being rendered, especially for a MiSeq instrument.

Customer tested on dev server, reported considerable imprvement.