### PR TITLE
filename method of the illumina component removed

### DIFF
--- a/Changes
+++ b/Changes
@@ -13,6 +13,7 @@ LIST OF CHANGES
      code to handle redundant links and paths is removed;
      if the target tileviz directory is not available, fall back to the one
      expected for the old-style run folder
+ - redundant filename method of the illumina component object removed
 
 release 87.3
  - for a run on ESA, redirect to an ESA url

--- a/lib/npg_tracking/glossary/composition/component/illumina.pm
+++ b/lib/npg_tracking/glossary/composition/component/illumina.pm
@@ -12,16 +12,6 @@ with qw( npg_tracking::glossary::composition::component
 
 our $VERSION = '0';
 
-sub filename {
-  my ($self, $ext) = @_;
-  $ext //= q[];
-  my $fn = join q[_], $self->id_run, $self->position.$self->tag_label;
-  if (defined $self->subset) {
-    $fn .= q[_].$self->subset;
-  }
-  return $fn.$ext;
-}
-
 __PACKAGE__->meta->make_immutable;
 1;
 __END__
@@ -76,29 +66,6 @@ in a multiplexed lane. See npg_tracking::glossary::tag
 
 An optional attribute, will default to 'target'.
 See npg_tracking::glossary::subset.
-
-=head2 filename
-
-A standard filename for a file. An optional extension can be specified,
-which is appended at the end of the standard filename root as given.
-
-  my $p = 'npg_tracking::glossary::composition::component::illumina';
-  my $c = $p->new(id_run => 2, position => 3);
-  $c->filename(); # 2_3 is returned
-  $c->filename('.fastq'); # 2_3.fastq is returned
-  $c->filename('_error_table'); # 2_3_error_table is returned
-
-  $c = $p->new(id_run => 2, position => 3, tag_index => 3);
-  $c->filename(); # 2_3#3 is returned
-  $c = $p->new(id_run => 2, position => 3, tag_index => undef);
-  $c->filename(); # 2_3 is returned
-
-  $c = $p->new(id_run => 2, position => 3, tag_index => 3, subset => 'phix');
-  $c->filename(); # 2_3#3_phix is returned
-  $c = $p->new(id_run => 2, position => 3, tag_index => undef, subset => 'human');
-  $c->filename(); # 2_3_human is returned
-  $c = $p->new(id_run => 2, position => 3, tag_index => undef, subset => undef);
-  $c->filename('.cram'); # 2_3.cram is returned
 
 =head2 compare_serialized
 

--- a/t/10-npg_tracking-glossary-composition-component-illumina.t
+++ b/t/10-npg_tracking-glossary-composition-component-illumina.t
@@ -1,6 +1,6 @@
 use strict;
 use warnings;
-use Test::More tests => 9;
+use Test::More tests => 8;
 use Test::Exception;
 
 my $pname = q[npg_tracking::glossary::composition::component::illumina];
@@ -149,21 +149,6 @@ subtest 'compute digest' => sub {
   $c  = $pname->new(position => 2, id_run => 1);
   is($c->digest, $d, 'the same sha256 digest');
   is($c->digest('md5'), $md5, 'the same md5');
-};
-
-subtest 'file names' => sub {
-  plan tests => 6;
-
-  my $c  = $pname->new(id_run => 1, position => 2);
-  is($c->filename, '1_2', 'without tag index');
-  $c  = $pname->new(id_run => 1, position => 2, tag_index => 1);
-  is($c->filename, '1_2#1', 'with tag index');
-  is($c->filename('.bam'), '1_2#1.bam', 'with tag index, extention given');
-  is($c->filename('_table'), '1_2#1_table', 'extention without dot given');
-  $c  = $pname->new(id_run => 1, position => 2, tag_index => 1, subset => 'phix');
-  is($c->filename, '1_2#1_phix', 'with subset');
-  $c  = $pname->new(id_run => 1, position => 2, subset => 'human');
-  is($c->filename, '1_2_human', 'with subset, without tag index');
 };
 
 1;


### PR DESCRIPTION
I doubt it was ever used. Now the moniker role should be used to generate file names