### PR TITLE
ensure the moniker role is compatible with MooseX::Getopt

### DIFF
--- a/lib/npg_tracking/glossary/moniker.pm
+++ b/lib/npg_tracking/glossary/moniker.pm
@@ -110,7 +110,6 @@ has [qw/_file_name_semantic _dir_path_semantic/] => (
   isa        => 'Bool',
   is         => 'ro',
   required   => 0,
-  init_arg   => {},
   lazy_build => 1,
 );
 sub _build__file_name_semantic {

--- a/t/10-npg_tracking-glossary-moniker.t
+++ b/t/10-npg_tracking-glossary-moniker.t
@@ -1,6 +1,6 @@
 use strict;
 use warnings;
-use Test::More tests => 9;
+use Test::More tests => 10;
 use Test::Exception;
 use Moose::Meta::Class;
 
@@ -28,7 +28,7 @@ $class->make_immutable;
 
 $class = Moose::Meta::Class->create_anon_class(
       superclasses=> ['npg_test::moniker'],
-      roles       => ['npg_tracking::glossary::moniker'] );
+      roles       => [qw/npg_tracking::glossary::moniker MooseX::Getopt/] );
 $class->make_immutable;
 my $class_name = $class->name();
 
@@ -55,6 +55,15 @@ subtest 'test dynamically created test class' => sub {
     'created class, composition defined via the the constructor';
   lives_ok {$moniker->file_name} 'can generate file name';
   lives_ok {$moniker->dir_path} 'can generate dir name';  
+};
+
+subtest 'test compatibility with MooseX::Getopt' => sub {
+  plan tests => 2;
+
+  local @ARGV = qw/--rpt_list 33:3:1/;
+  my $obj = $class_name->new_with_options();
+  isa_ok ($obj, $class_name);
+  is($obj->rpt_list, '33:3:1', 'rpt_list attribute value');
 };
 
 subtest 'no semantically meaningful name' => sub {


### PR DESCRIPTION
Seems to be a bug in MooseX::Getopt which makes its introspection of a private attribute with 'init_arg'  set to {} to go wrong. As a consequence, two entries like ''HASH(0x71b9480)!',' appears in the option spec that is passed to Getopt::Long. This spec is then rejected with an error

Error in option spec: "HASH(0x71b9480)!"
Error in option spec: "HASH(0x71b9480)!"
