### PR TITLE
flexible comparison that allows for the clone not to be tagged

### DIFF
--- a/t/10-npg_tracking-glossary-composition-component-illumina.t
+++ b/t/10-npg_tracking-glossary-composition-component-illumina.t
@@ -105,8 +105,8 @@ subtest 'JSON serialization' => sub {
 
   my $version = `git describe --dirty --always`;
   $version =~ s/\s+//;
-  $j = qq({"__CLASS__":"npg_tracking::glossary::composition::component::illumina-$version","id_run":1,"position":2,"subset":"human","tag_index":3});
-  is ($c->freeze(with_class_names => 1), $j,
+  $j = qr/\{"__CLASS__":"npg_tracking::glossary::composition::component::illumina-(.+)?$version","id_run":1,"position":2,"subset":"human","tag_index":3\}/;
+  like ($c->freeze(with_class_names => 1), $j,
     'serialization to an ordered json string with a class name');
 
   $j = '{"__CLASS__":"npg_tracking::glossary::composition::component::illumina-100.0","id_run":1,"position":2,"subset":"human","tag_index":3}';  

--- a/t/10-npg_tracking-glossary-composition.t
+++ b/t/10-npg_tracking-glossary-composition.t
@@ -154,8 +154,8 @@ subtest 'serialization' => sub {
 
   my $version = `git describe --dirty --always`;
   $version =~ s/\s+//;
-  my $ej = qq({"__CLASS__":"npg_tracking::glossary::composition-$version","components":[{"__CLASS__":"npg_tracking::glossary::composition::component::illumina-$version","id_run":1,"position":2,"subset":"human"},{"__CLASS__":"npg_tracking::glossary::composition::component::illumina-$version","id_run":1,"position":2,"subset":"phix"}]});
-  is ($cmps->freeze(with_class_names => 1), $ej, 'json with class names');
+  my $ej = qr/\{"__CLASS__":"npg_tracking::glossary::composition-(.+)?$version","components":\[\{"__CLASS__":"npg_tracking::glossary::composition::component::illumina-(.+)?$version","id_run":1,"position":2,"subset":"human"\},\{"__CLASS__":"npg_tracking::glossary::composition::component::illumina-(.+)?$version","id_run":1,"position":2,"subset":"phix"\}\]\}/;
+  like ($cmps->freeze(with_class_names => 1), $ej, 'json with class names');
   
   $f = npg_tracking::glossary::composition::factory->new();
   $f->add_component($c2, $c1);


### PR DESCRIPTION
If the clone is not tagged (as it happens in Travis CI) and the git tag does not start with a number, we add 0.0- to the module version when building the package, see https://github.com/wtsi-npg/perl-dnap-utilities/blob/5c3fe8575c4da2fe712d6e3022623cfe10618149/lib/WTSI/DNAP/Utilities/Build.pm#L94