### PR TITLE
use mtime to recognise when a status file has changed

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -152,6 +152,7 @@ my $builder = $class->new(
                 'File::Type'                      => '0.22',
                 'File::Temp'                      => 0,
                 'File::chdir'                     => 0,
+                'File::stat'                      => 0,
                 'GD'                              => '2.35',
                 'GD::Text'                        => 0,
                 'Getopt::Long'                    => '2.37',

--- a/Changes
+++ b/Changes
@@ -1,5 +1,9 @@
 LIST OF CHANGES
 
+release 88.1
+ - status monitor running with inotify disabled should be able to recognise
+   when a cached file is changed
+
 release 88.0
  - tracking database:
      add column `incompatible_tag` to the tag table;

--- a/Changes
+++ b/Changes
@@ -1,8 +1,12 @@
 LIST OF CHANGES
 
 release 88.1
- - status monitor running with inotify disabled should be able to recognise
-   when a cached file is changed
+ - status monitor running with inotify disabled should be able to
+   recognise when a cached file is changed
+ - 2 sec sleep introduced in the beginning of the job that saves
+   statuses to a file to ensure no two statuses of the same run/lane
+   have the same timestamp so that the iscurrent db flag could be
+   assigned inambigiously when the statuses are saved to a database
 
 release 88.0
  - tracking database:

--- a/bin/npg_status2file
+++ b/bin/npg_status2file
@@ -29,6 +29,12 @@ if ( !(-d $dir_out && -w $dir_out) ) {
   croak "--dir_out option $dir_out should be a writable directory";
 }
 
+#####
+# Ensure no two statuses of the same run/lane have the same
+# timestamp so that the iscurrent db flag could be assigned
+# inambigiously. 
+sleep 2;
+
 my $path = npg_tracking::status->new(
    id_run => $id_run, status => $status, lanes => \@lanes)->to_file($dir_out);
 

--- a/lib/npg_tracking/monitor/status.pm
+++ b/lib/npg_tracking/monitor/status.pm
@@ -731,6 +731,8 @@ A Moose hook for object destruction; calls cancel_watch().
 
 =item File::Basename
 
+=item File::stat
+
 =item Errno
 
 =item Try::Tiny

--- a/lib/npg_tracking/monitor/status.pm
+++ b/lib/npg_tracking/monitor/status.pm
@@ -12,6 +12,7 @@ use File::Spec::Functions;
 use Linux::Inotify2;
 use Sys::Filesystem;
 use Sys::Filesystem::MountPoint qw/path_to_mount_point/;
+use File::stat;
 
 use npg_tracking::util::types;
 use npg_tracking::illumina::run::folder;
@@ -270,13 +271,21 @@ sub _update_status4files {
   }
 
   my $num_saved = 0;
+
   foreach my $file ( @{$files} ) {
-    next if $self->_file_in_cache($file);
+    my $modify_time = stat($file)->mtime;
+    my $cached_time = $self->_file_in_cache($file);
+    #####
+    # If the pipeline is run repeatedly using the same analysis
+    # directory, status files might get overwritten. We should
+    # save the latest status even if this status had been saved
+    # in the past.
+    next if (defined $cached_time && ($cached_time eq $modify_time));
     try {
       $self->_log("\nReading status from $file");
       my $status = $self->_read_status($file, $runfolder_path);
       $self->_update_status($status);
-      $self->_cache_file($file, 1);
+      $self->_cache_file($file, $modify_time);
       $num_saved++;
     } catch {
       $self->_log("Error saving status: $_\n");


### PR DESCRIPTION
With this fix the behaviour of the monitor becomes consistent regardless of whether inotify is enabled.

Also ensure no two statuses of the same run/lane have the same timestamp so that the iscurrent db flag could be assigned inambigiously. 