### PR TITLE
restrict test_requires version of Test::Compile to < 1.4

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -85,6 +85,10 @@ my $builder = $class->new(
                 'Module::Build'                   => '>= 0.42',
           },
 
+          'test_requires' => {
+                'Test::Compile'                   => '< 1.4',
+          },
+
           'build_requires' => {
                 'ExtUtils::CBuilder'              => 0,
                 'Archive::Tar'                    => 0,


### PR DESCRIPTION
00-scripts_compile.t failing with Test::Compile version 2 in travis.