### PR TITLE
add uses_patterned_flowcell attribute to long_info. 

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,7 @@
 LIST OF CHANGES
 
+ - add uses_patterned_flowcell attribute to long_info
+
 release 89.1.0
  - Where semantic names are not possible, standard file and directory
    names are based on sha256 digest of the composition JSON

--- a/lib/npg_tracking/illumina/run/long_info.pm
+++ b/lib/npg_tracking/illumina/run/long_info.pm
@@ -590,6 +590,23 @@ sub is_i5opposite {
           $self->platform_MiniSeq() or $self->platform_NextSeq());
 }
 
+=head2 uses_patterned_flowcell
+
+HiSeqX, HiSeq3000/4000, and NovaSeq use patterned flowcells
+https://www.illumina.com/science/technology/next-generation-sequencing/sequencing-technology/patterned-flow-cells.html
+
+Method returns true if this is one of those platforms.
+
+=cut
+
+sub uses_patterned_flowcell {
+  my $self = shift;
+
+  return ($self->platform_HiSeqX
+          or $self->platform_HiSeq4000
+          or $self->platform_NovaSeq);
+}
+
 =head2 instrument_side
 
 Returns the instrument side (A or B) if available or an empty string.

--- a/t/60-illumina-run-long_info.t
+++ b/t/60-illumina-run-long_info.t
@@ -28,7 +28,7 @@ package main;
 my $basedir = tempdir( CLEANUP => 1 );
 
 subtest 'retrieving information from runParameters.xml' => sub {
-  plan tests => 142;
+  plan tests => 155;
 
   my $rf = join q[/], $basedir, 'runfolder';
   mkdir $rf;
@@ -57,6 +57,7 @@ subtest 'retrieving information from runParameters.xml' => sub {
   my @platforms = qw/MiniSeq HiSeq HiSeq4000 HiSeqX
                      MiSeq NextSeq NovaSeq/;
   my @i5opp_platforms = map {lc $_} qw/MiniSeq HiSeq4000 HiSeqX NextSeq/;
+  my @patterned_flowcell_platforms = map {lc $_} qw/HiSeq4000 HiSeqX NovaSeq/;
 
   for my $f (@rp_files) {
     note $f;
@@ -112,6 +113,14 @@ subtest 'retrieving information from runParameters.xml' => sub {
       ok ($li->is_i5opposite(), 'i5opposite');
     } else {
       ok (!$li->is_i5opposite(), 'not i5opposite');
+    }
+
+    my @pfc = grep { $pl =~ /\A$_/ } @patterned_flowcell_platforms;
+    if (scalar @pfc > 1) {die 'Too many matches'};
+    if (@pfc) {
+      ok ($li->uses_patterned_flowcell, 'patterned flowcell');
+    } else {
+      ok (!$li->uses_patterned_flowcell, 'not patterned flowcell');
     }
 
     unlink $name;


### PR DESCRIPTION
This determines the optical distance used when marking duplicates.