### PR TITLE
Add no_archive folder to npg_tracking::ilumina::run::folder

### DIFF
--- a/lib/npg_tracking/illumina/run/folder.pm
+++ b/lib/npg_tracking/illumina/run/folder.pm
@@ -26,6 +26,7 @@ Readonly::Scalar my  $INTENSITIES_DIR   => q{Intensities};
 Readonly::Scalar my  $ANALYSIS_DIR_GLOB => q{_basecalls_};
 Readonly::Scalar my  $NO_CAL_DIR        => q{no_cal};
 Readonly::Scalar my  $ARCHIVE_DIR       => q{archive};
+Readonly::Scalar my  $NO_ARCHIVE_DIR    => q{no_archive};
 Readonly::Scalar our $SUMMARY_LINK      => q{Latest_Summary};
 
 Readonly::Hash my %NPG_PATH  => (
@@ -35,6 +36,7 @@ Readonly::Hash my %NPG_PATH  => (
   q{basecall_path}     => 'Path to the "BaseCalls" directory',
   q{recalibrated_path} => 'Path to the recalibrated qualities directory',
   q{archive_path}      => 'Path to the directory with data ready for archiving',
+  q{no_archive_path}   => 'Path to the directory with data not to be archived',
   q{qc_path}           => 'Path directory with top level QC data',
 );
 
@@ -177,6 +179,11 @@ sub _build_recalibrated_path {
 sub _build_archive_path {
   my ($self) = @_;
   return $self->recalibrated_path() . q{/} . $ARCHIVE_DIR;
+}
+
+sub _build_no_archive_path {
+  my ($self) = @_;
+  return $self->analysis_path() . q{/} . $NO_ARCHIVE_DIR;
 }
 
 sub _build_qc_path {
@@ -373,6 +380,8 @@ recalibrated directory, which will be used to construct other paths from.
 
 =head2 archive_path - ro accessor to the archive level directory path
 
+=head2 no_archive_path - ro accessor to the no_archive level directory path
+
 =head2 subpath
 
 One of given paths from which the run folder path might be inferred.
@@ -420,7 +429,7 @@ Might be undefined.
 
 =head1 LICENSE AND COPYRIGHT
 
-Copyright (C) 2018 GRL
+Copyright (C) 2018, 2019 Genome Research Limited
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/t/60-illumina-run-folder.t
+++ b/t/60-illumina-run-folder.t
@@ -42,7 +42,7 @@ local $ENV{dev} = qw{non_existant_dev_enviroment}; #prevent pickup of user's con
 local $ENV{TEST_DIR} = $basedir; #so when npg_tracking::illumina::run::folder globs the test director
 
 subtest 'standard runfolder' => sub {
-  plan tests => 25;
+  plan tests => 26;
 
   my $instr = 'HS2';
   my $id_run = q{1234};
@@ -56,6 +56,7 @@ subtest 'standard runfolder' => sub {
   my $bbcalls_subpath = $intensities_subpath . q{/BAM_basecalls_2009-10-01};
   my $pb_cal_subpath = $bbcalls_subpath . q{/no_cal};
   my $archive_subpath = $pb_cal_subpath . q{/archive};
+  my $no_archive_subpath = $bbcalls_subpath . q{/no_archive};
   my $qc_subpath = $archive_subpath . q{/qc};
   my $config_path = $runfolder_path . q{/Config};
 
@@ -96,6 +97,7 @@ subtest 'standard runfolder' => sub {
   is($path_info->analysis_path(), $bbcalls_subpath,
     q{found a recalibrated directory, so able to work out analysis_path});
   is($path_info->archive_path(), $archive_subpath, 'archive path');
+  is($path_info->no_archive_path(), $no_archive_subpath, 'no_archive path');
   is($path_info->qc_path(), $qc_subpath, q{qc_path});
   is($path_info->basecall_path(), $basecalls_subpath,
     q{basecalls_subpath});


### PR DESCRIPTION
This directory holds data that persists between functions but that we don't want to archive to IRODS.