### PR TITLE
minor change to npg_tracking::util::pipeline_config

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 LIST OF CHANGES
 
+ - minor change to npg_tracking::util::pipeline_config to move bqsr and
+   haplotype caller to a tertiary section which can be set by specifically
+   by reference or by using a default study config.
  - npg_tracking::util::pipeline_config is refactored to restrict access
    to attributes which should not be set by the caller (local_bin, product_config)
    and to enable setting product release configuration file path via the

--- a/MANIFEST
+++ b/MANIFEST
@@ -798,6 +798,7 @@ t/data/npg_api_run/npg/run/604.xml
 t/data/npg_api_run/npg/run/636.xml
 t/data/pipeline_config/study_config_present/product_release.yml
 t/data/pipeline_config/study_config_absent/product_release.yml
+t/data/pipeline_config/study_config_tertiary_present/product_release.yml
 t/data/rendered/20-view-administration_create_instrument_mod.html
 t/data/rendered/20-view-administration_create_instrument_status.html
 t/data/rendered/20-view-administration_create_run_status.html

--- a/t/10-npg_tracking-util-pipeline_config.t
+++ b/t/10-npg_tracking-util-pipeline_config.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings;
 use Cwd;
-use Test::More tests => 16;
+use Test::More tests => 21;
 use Test::Exception;
 use Test::Warn;
 
@@ -65,4 +65,14 @@ is_deeply ($study_hash, $expected, 'correct default data returned');
 $study_hash = $c->study_config($l, 1);
 is_deeply ($study_hash, {}, 'strict mode - an empty hash is returned');
 
+my $pctfile = 't/data/pipeline_config/study_config_tertiary_present/product_release.yml';
+$c = t::pipeline_config->new(conf_path => 't/data/pipeline_config/study_config_tertiary_present');
+is ( $c->product_conf_file_path(), $pctfile, 'product conf file path');
+lives_ok { $c->_product_config() } 'product conf file path read OK';
+is ($c->local_bin, join(q[/], getcwd(), 't'), 'local_bin path is correct');
+$study_hash = $c->study_config($l);
+$expected = {study_id => 700, s3 => {enable => 1, notify => 1}, irods => {enable => '', notify => ''}, tertiary => {'Homo_sapiens' => {'GRCh37_53' => {'haplotype_caller' => {enable => 1, sample_chunking => 'hs37primary', sample_chunking_number => 24}}}}};
+is_deeply ($study_hash, $expected, 'correct study with tertiary data returned');
+$study_hash = $c->study_config($l, 1);
+is_deeply ($study_hash, $expected, 'correct study with tertiary data returned in strict mode ');
 1;

--- a/t/data/pipeline_config/study_config_tertiary_present/product_release.yml
+++ b/t/data/pipeline_config/study_config_tertiary_present/product_release.yml
@@ -1,0 +1,23 @@
+---
+default:
+  s3:
+    enable: false
+    notify: false
+  irods:
+    enable: true
+    notify: false
+study:
+  - study_id: "700"
+    s3:
+      enable: true
+      notify: true
+    irods:
+      enable: false
+      notify: false
+    tertiary:
+      Homo_sapiens:
+        GRCh37_53:
+          haplotype_caller:
+            enable: true
+            sample_chunking: hs37primary
+            sample_chunking_number: 24


### PR DESCRIPTION
Assumes tertiary analysis will only be set at the study, and not global, level for some time.