### PR TITLE
Add COG-UK sequencing run metadata upload client.

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -86,7 +86,7 @@ my $builder = $class->new(
           },
 
           'test_requires' => {
-                'Test::Compile'                   => '< 1.4',
+              'Test::Compile'                     => '< 1.4',
           },
 
           'build_requires' => {
@@ -102,6 +102,7 @@ my $builder = $class->new(
                 'Test::Distribution'              => 0,
                 'Test::Deep'                      => '0.103',
                 'Test::Exception'                 => '0.27',
+                'Test::HTTP::Server'              =>  0,
                 'Test::LongString'                => 0,
                 'Test::MockModule'                => 0,
                 'Test::MockObject'                => 0,
@@ -129,6 +130,7 @@ my $builder = $class->new(
                 'Config::Auto'                    => 0,
                 'Crypt::CBC'                      => 0,
                 'Cwd'                             => 0,
+                'Data::Dump'                      => 0,
                 'Date::Parse'                     => '2.27',
                 'DateTime'                        => '0.5',
                 'DateTime::TimeZone'              => 0,
@@ -214,6 +216,7 @@ my $builder = $class->new(
                 'Sys::Hostname'                   => '1.11',
                 'Template'                        => '2.19',
                 'Try::Tiny'                       => 0,
+                'URI'                             => 0,
                 'URI::Escape'                     => 0,
                 'URI::URL'                        => 0,
                 'utf8'                            => 0,

--- a/lib/npg_tracking/heron/upload/metadata_client.pm
+++ b/lib/npg_tracking/heron/upload/metadata_client.pm
@@ -1,0 +1,198 @@
+package npg_tracking::heron::upload::metadata_client;
+
+use strict;
+use warnings;
+
+use Data::Dump qw(pp);
+use JSON;
+use LWP::UserAgent;
+use Moose;
+use MooseX::StrictConstructor;
+use URI;
+
+with qw[
+    WTSI::DNAP::Utilities::Loggable
+    WTSI::DNAP::Utilities::JSONCodec
+];
+
+our $VERSION = '0';
+
+our $JSON_CONTENT_TYPE = 'application/json';
+
+has 'username' =>
+    (isa           => 'Str',
+     is            => 'ro',
+     required      => 1,
+     documentation => 'The registered user name for the COG-Uk API account',);
+
+has 'token' =>
+    (isa           => 'Str',
+     is            => 'ro',
+     required      => 1,
+     documentation => 'The registered access token for the COG-UK API account',);
+
+has 'api_uri' =>
+  (isa           => 'URI',
+   is            => 'ro',
+   required      => 1,
+   default       => sub { return URI->new('https://localhost') },
+   documentation => 'COG-UK API endpoint URI to receive sequencing metadata',);
+
+=head2 send_metadata
+
+  Arg[1]     : Library name, Str.
+  Arg[n]     : Runs, npg_tracking::heron::upload::run.
+
+  Example    : my $response_content = $client->send_metadata($library_name, @runs)
+  Description: Return the (decoded) response data on successful upload of metadata
+               to the COG-UK API endpoint, or raise an error if some or all of the
+               metadata were rejected.
+  Returntype : HashRef.
+
+=cut
+
+sub send_metadata {
+  my ($self, $library_name, @runs) = @_;
+
+  my $metadata = $self->_make_library_metadata($library_name);
+  foreach my $run (@runs) {
+    push @{$metadata->{runs}}, $self->_make_run_metadata($run);
+  }
+
+  $metadata->{username} = $self->username;
+  $metadata->{token}    = $self->token;
+
+  my $req_content = $self->encode($metadata);
+
+  my $ua = LWP::UserAgent->new;
+  $ua->default_header('Content-Type' => $JSON_CONTENT_TYPE);
+
+  my $uri = $self->_seq_add_uri;
+  $self->debug(sprintf q(POST to '%s', content %s ),
+                       $uri, $req_content);
+
+  my $response = $ua->post($uri, Content => $req_content);
+  $self->debug(sprintf q(POST returned code %d, %s),
+                       $response->code, $response->message);
+
+  my $res_content;
+  if ($response->is_success) {
+    my $res_json = $response->content;
+    $self->debug('Response JSON ', $res_json);
+    $res_content = $self->decode($res_json);
+  }
+  else {
+    $self->logcroak(sprintf q(Failed to get results from URI '%s': %s),
+                            $uri, $response->message);
+  }
+
+  foreach my $add (@{$res_content->{new}}) {
+    $self->info('Added ', pp($add));
+  }
+  foreach my $update (@{$res_content->{updated}}) {
+    $self->info('Updated ', pp($update));
+  }
+  foreach my $ignore (@{$res_content->{ignored}}) {
+    $self->info('Ignored ', $ignore);
+  }
+
+  my $summary = sprintf q(POST to %s failed; %d errors, %d warnings, ) .
+                        q(%d updated, %d ignored),
+                        $uri, $res_content->{errors}, $res_content->{warnings},
+                        scalar @{$res_content->{updated}},
+                        scalar @{$res_content->{ignored}};
+
+  if ($res_content->{success}) {
+    foreach my $message (@{$res_content->{messages}}) {
+      $self->info('Endpoint message: ', pp($message));
+    }
+    $self->info($summary);
+  }
+  else {
+    foreach my $message (@{$res_content->{messages}}) {
+      $self->error('Endpoint message: ', pp($message));
+    }
+    $self->logcroak($summary);
+  }
+
+  return $res_content;
+}
+
+sub _seq_add_uri {
+  my ($self) = @_;
+
+  my $uri = $self->api_uri->clone;
+  $uri->path('api/v2/process/sequencing/add/');
+
+  return $uri;
+}
+
+sub _make_library_metadata {
+  my ($self, $library_name) = @_;
+
+  $library_name or $self->logconfess('An empty library_name was supplied');
+
+  return {library_name => $library_name,
+          runs         => []};
+}
+
+sub _make_run_metadata {
+  my ($self, $run) = @_;
+
+  return {run_name         => $run->name,
+          instrument_make  => $run->instrument_make,
+          instrument_model => $run->instrument_model};
+}
+
+__PACKAGE__->meta->make_immutable;
+
+no Moose;
+
+1;
+
+__END__
+
+=head1 NAME
+
+npg_tracking::heron::upload::metadata_client
+
+=head1 VERSION
+
+=head1 SYNOPSIS
+
+=head1 DESCRIPTION
+
+Client capable of uploading sequencing run metadata to the COG-UK API
+endpoint described at https://docs.covid19.climb.ac.uk/metadata.
+
+=head1 SUBROUTINES/METHODS
+
+=head1 DIAGNOSTICS
+
+=head1 CONFIGURATION AND ENVIRONMENT
+
+=head1 DEPENDENCIES
+
+=head1 INCOMPATIBILITIES
+
+=head1 BUGS AND LIMITATIONS
+
+=head1 AUTHOR
+
+Keith James <kdj@sanger.ac.uk>
+
+=head1 LICENSE AND COPYRIGHT
+
+Copyright (C) 2020, Genome Research Limited. All Rights Reserved.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the Perl Artistic License or the GNU General
+Public License as published by the Free Software Foundation, either
+version 3 of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+=cut

--- a/lib/npg_tracking/heron/upload/run.pm
+++ b/lib/npg_tracking/heron/upload/run.pm
@@ -1,0 +1,134 @@
+package npg_tracking::heron::upload::run;
+
+use strict;
+
+use List::MoreUtils qw(any);
+use Moose;
+use MooseX::StrictConstructor;
+
+with qw(WTSI::DNAP::Utilities::Loggable);
+
+our $VERSION = '0';
+
+# COG-UK instrument make controlled vocabulary, see@
+#
+# https://docs.covid19.climb.ac.uk/metadata
+#
+our $ILLUMINA = qw(ILLUMINA);
+our $ONT      = qw(OXFORD_NANOPORE);
+our $PACBIO   = qw(PACIFIC_BIOSCIENCES);
+
+our $NAME_PREFIX = qw(CAMB);
+
+has 'id' =>
+    (isa           => 'Str',
+     is            => 'ro',
+     required      => 1,
+     documentation => 'The run identifier from the instrument',);
+
+has 'instrument_make' =>
+    (isa           => 'Str',
+     is            => 'ro',
+     required      => 1,
+     documentation => 'The instrument make (controlled vocabulary)',);
+
+has 'instrument_model' =>
+    (isa           => 'Str',
+     is            => 'ro',
+     required      => 1,
+     documentation => 'The instrument model',);
+
+
+=head2 BUILD
+
+Validates constructor arguments for correctness.
+
+=cut
+
+sub BUILD {
+   my ($self, $args) = @_;
+
+   $args->{id} or
+       $self->logconfess('An empty or zero id was supplied');
+   $args->{instrument_make}  or
+       $self->logconfess('An empty instrument_make was supplied');
+   $args->{instrument_model} or
+       $self->logconfess('An empty instrument_model was supplied');
+
+   my $make = $args->{instrument_make};
+   if (not any { $make eq $_ } ($ILLUMINA, $ONT, $PACBIO)) {
+      $self->logconfess("Invalid instrument make '$make'");
+   }
+
+   return 1;
+}
+
+=head2 name
+
+  Example    : my $name = $run->name
+  Description: Return a COG-UK compliant run name.
+  Returntype : Str
+
+=cut
+
+sub name {
+   my ($self) = @_;
+
+   return sprintf q(%s-%s), $NAME_PREFIX, $self->id;
+}
+
+__PACKAGE__->meta->make_immutable;
+
+no Moose;
+
+1;
+
+__END__
+
+=head1 NAME
+
+npg_tracking::heron::upload::run
+
+=head1 VERSION
+
+=head1 SYNOPSIS
+
+=head1 DESCRIPTION
+
+Represents an instrument run to be uploaded to the COG-UK endpoint
+described at at https://docs.covid19.climb.ac.uk/metadata.
+
+Instances will validate their constructor arguments and raise an error
+if any are invalid according to the description above.
+
+=head1 SUBROUTINES/METHODS
+
+=head1 DIAGNOSTICS
+
+=head1 CONFIGURATION AND ENVIRONMENT
+
+=head1 DEPENDENCIES
+
+=head1 INCOMPATIBILITIES
+
+=head1 BUGS AND LIMITATIONS
+
+=head1 AUTHOR
+
+Keith James <kdj@sanger.ac.uk>
+
+=head1 LICENSE AND COPYRIGHT
+
+Copyright (C) 2020, Genome Research Limited. All Rights Reserved.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the Perl Artistic License or the GNU General
+Public License as published by the Free Software Foundation, either
+version 3 of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+=cut

--- a/t/100-npg_tracking-heron-metadata-upload.t
+++ b/t/100-npg_tracking-heron-metadata-upload.t
@@ -1,0 +1,126 @@
+use strict;
+use warnings;
+
+use File::Temp qw(tempdir);
+use JSON;
+use Log::Log4perl qw[:levels];
+use Test::HTTP::Server;
+use Test::More;
+use Test::Exception;
+use URI;
+
+use_ok('npg_tracking::heron::upload::run');
+use_ok('npg_tracking::heron::upload::metadata_client');
+
+my $logfile = join q[/], tempdir(CLEANUP => 1), 'logfile';
+note "Log file: $logfile";
+Log::Log4perl->easy_init({layout => '%d %-5p %c - %m%n',
+                          level  => $DEBUG,
+                          file   => $logfile,
+                          utf8   => 1});
+
+my $request_success = 1;
+sub Test::HTTP::Server::Request::api {
+  if ($request_success) {
+    # Example of a success response
+    return encode_json({errors   => 0,
+                        warnings => 0,
+                        messages => [],
+                        new      => [
+                            ['object_type1', 'object_uuid1', 'object_id1'],
+                            ['object_type1', 'object_uuid2', 'object_id2'],
+                            ['object_type1', 'object_uuid3', 'object_id3'],
+                        ],
+                        updated  => [],
+                        ignored  => [],
+
+                        success  => 1});
+  }
+
+  # Example of a failure response
+  return encode_json({errors   => 1,
+                      warnings => 0,
+                      messages => [],
+                      new      => [],
+                      updated  => [],
+                      ignored  => [],
+
+                      success  => 0});
+}
+
+my $library_name = 'test_library_name';
+my $make  = 'ILLUMINA';
+my $model = 'NovaSeq';
+my @instrument_args = (instrument_make  => $make,
+                       instrument_model => $model);
+
+# We can make valid runs
+ok(npg_tracking::heron::upload::run->new(id               => 'run1',
+                                         instrument_make  => 'ILLUMINA',
+                                         instrument_model => 'SomeModel'),
+   'ILLUMINA make is OK');
+ok(npg_tracking::heron::upload::run->new(id               => 'run1',
+                                         instrument_make  => 'OXFORD_NANOPORE',
+                                         instrument_model => 'SomeModel'),
+   'OXFORD_NANOPORE make is OK');
+ok(npg_tracking::heron::upload::run->new(id               => 'run1',
+                                         instrument_make  => 'PACIFIC_BIOSCIENCES',
+                                         instrument_model => 'SomeModel'),
+   'PACIFIC_BIOSCIENCES make is OK');
+
+like(npg_tracking::heron::upload::run->new(id               => 'run1',
+                                           instrument_make  => 'ILLUMINA',
+                                           instrument_model => 'SomeModel')->name,
+     qr{CAMB-.*}, 'Run name has correct form');
+
+dies_ok {
+  npg_tracking::heron::upload::run->new(name             => 'run1',
+                                        instrument_make  => 'invalid_make',
+                                        instrument_model => 'SomeModel');
+} 'run will not accept an invalid make';
+
+my @runs = (npg_tracking::heron::upload::run->new(id => 'run1', @instrument_args),
+            npg_tracking::heron::upload::run->new(id => 'run2', @instrument_args),
+            npg_tracking::heron::upload::run->new(id => 'run3', @instrument_args));
+
+my $server = Test::HTTP::Server->new;
+my $server_uri = URI->new($server->uri);
+my $client = npg_tracking::heron::upload::metadata_client->new
+    (username  => 'test_username',
+     token     => 'test_token',
+     api_uri   => $server_uri);
+
+is($client->api_uri, $server_uri, 'has expected URI') or diag explain
+    "Expected $server_uri, but got " . $client->api_uri;
+
+my $add_success_response = {
+    errors   => 0,
+    warnings => 0,
+    messages => [],
+    new      => [
+          ['object_type1', 'object_uuid1', 'object_id1'],
+          ['object_type1', 'object_uuid2', 'object_id2'],
+          ['object_type1', 'object_uuid3', 'object_id3'],
+    ],
+    updated  => [],
+    ignored  => [],
+
+    success  => 1
+};
+
+# We can send POST requests and accept a success response
+my $response = $client->send_metadata($library_name, @runs);
+ok($response, 'Send response successful');
+is_deeply($response, $add_success_response) or
+    diag explain $response;
+
+# We error on  a failure response
+undef $server;
+$request_success = 0;
+$server = Test::HTTP::Server->new;
+
+dies_ok {
+  $response = $client->send_metadata($library_name, @runs);
+} 'Sending metadata dies on error response';
+
+done_testing();


### PR DESCRIPTION
POSTs metadata to the COG-UK metadata API endpoint described at
https://docs.covid19.climb.ac.uk/upload-instructions.