### PR TITLE
Change instrument formats page to show only current formats

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,7 @@
 LIST OF CHANGES
 
+ - Change instrument format page to only show current instruments
+
 release 91.11.0
  - a partial reimplementation of the serialization framework for components
    and compositions in order to speed-up frequently used methods 

--- a/data/templates/instrument_format_list.tt2
+++ b/data/templates/instrument_format_list.tt2
@@ -9,18 +9,18 @@
     <tr>
       <th>Instrument Manufacturer</th>
       <th>Instrument Model</th>
-      <th>Is Current</th>
-      <th>Instrument Count</th>
+      <th>Current Instrument Count</th>
     </tr>
   </thead>
   <tbody>
 [% FOREACH instrument_format = model.instrument_formats %]
-  <tr>
-    <td><a href="[% SCRIPT_NAME %]/manufacturer/[% instrument_format.id_manufacturer %]">[% instrument_format.manufacturer.name %]</a></td>
-    <td><a href="[% SCRIPT_NAME %]/instrument_format/[% instrument_format.id_instrument_format %]">[% instrument_format.model %]</a></td>
-    <td>[% IF instrument_format.iscurrent %]<img src="/icons/silk/tick.png" alt="tick.png" title="yes" />[% ELSE %]<img src="/icons/silk/cross.png" alt="cross.png" title="no" />[% END %]</td>
-    <td>[% instrument_format.instrument_count %]</td>
-  </tr>
+  [% IF instrument_format.iscurrent %]
+    <tr>
+      <td><a href="[% SCRIPT_NAME %]/manufacturer/[% instrument_format.id_manufacturer %]">[% instrument_format.manufacturer.name %]</a></td>
+      <td><a href="[% SCRIPT_NAME %]/instrument_format/[% instrument_format.id_instrument_format %]">[% instrument_format.model %]</a></td>
+      <td>[% instrument_format.current_instruments_count %]</td>
+    </tr>
+  [% END %]
 [% END %]
   </tbody>
 </table>

--- a/data/templates/instrument_top.tt2
+++ b/data/templates/instrument_top.tt2
@@ -1,4 +1,4 @@
-[% labels    = ['current status', 'formats'] -%]
+[% labels    = ['current status', 'current formats'] -%]
 [% addresses = ['instrument/graphical', 'instrument_format'] -%]
 [% counts    = [0, 2] -%]
 <p class="npgmenu1">

--- a/lib/npg/model/instrument_format.pm
+++ b/lib/npg/model/instrument_format.pm
@@ -92,21 +92,9 @@ sub current_instruments {
   return $self->{'current_instruments'};
 }
 
-sub instrument_count {
+sub current_instruments_count {
   my $self  = shift;
-  my $query = q(SELECT COUNT(*)
-                FROM   instrument
-                WHERE  id_instrument_format = ?);
-  my $ref = [];
-  eval {
-    $ref = $self->util->dbh->selectall_arrayref($query, {},
-                                                $self->id_instrument_format());
-  } or do {
-    carp $EVAL_ERROR;
-    return;
-  };
-
-  return $ref->[0]->[0] || q(0);
+  return scalar @{$self->current_instruments()};
 }
 
 sub is_used_sequencer_type {
@@ -192,9 +180,9 @@ initialise an object based on model being provided
 
   my $arCurrentInstrumentFormats = $oInstrumentFormat->current_instrument_formats();
 
-=head2 instrument_count - count of instruments of this instrument_format
+=head2 current_instruments_count - count of instruments of this instrument_format
 
-  my $iInstrumentCount = $oInstrumentFormat->instrument_count();
+  my $iCurrentInstrumentCount = $oInstrumentFormat->current_instrument_count();
 
 =head2 is_used_sequencer_type
 

--- a/t/10-model-instrument_format.t
+++ b/t/10-model-instrument_format.t
@@ -2,7 +2,7 @@ use strict;
 use warnings;
 use t::util;
 use npg::model::instrument;
-use Test::More tests => 15;
+use Test::More tests => 13;
 use Test::Trap;
 use Test::Deep;
 
@@ -56,26 +56,8 @@ my $util = t::util->new({fixtures => 1});
          util => $util,
          id_instrument_format => 4,
         });
-  my $ic = $if->instrument_count();
-  is($ic, 13, 'instrument count');
-}
-
-{
-  trap {
-    my $if = $IF->new({
-           util => 'foo',
-          });
-    is($if->instrument_count(), undef, 'database query failure');
-  };
-}
-
-{
-  my $if = $IF->new({
-         util => $util,
-         id_instrument_format => 0,
-        });
-  my $ic = $if->instrument_count();
-  is($ic, 0, 'zero instrument count');
+  my $ic = $if->current_instruments_count();
+  is($ic, 12, 'current instrument count');
 }
 
 


### PR DESCRIPTION
- Remove non-current instrument formats and `Is Current` column
- Change `Instrument Count` column to `Current Instrument Count`
- Rename link in header from `formats` to `current formats`
Closes #595 