### PR TITLE
Optionally save run and lane statuses to the database.

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 LIST OF CHANGES
 
+ - Extend npg_status2file script to optionally save statuses to the tracking
+   database
+ 
 release 91.12.0
  - Change instrument and instrument format pages to only show current
    instruments and instrument formats

--- a/Changes
+++ b/Changes
@@ -1,7 +1,7 @@
 LIST OF CHANGES
 
  - Extend npg_status2file script to optionally save statuses to the tracking
-   database
+   database and renamed the script to npg_status_save.
  
 release 91.12.0
  - Change instrument and instrument format pages to only show current

--- a/MANIFEST
+++ b/MANIFEST
@@ -3,7 +3,7 @@ bin/event_notifications
 bin/illumina_instruments_uptime
 bin/npg_daemon_control
 bin/npg_move_runfolder
-bin/npg_status2file
+bin/npg_status_save
 bin/npg_status_watcher
 bin/staging_area_monitor
 bin/npg_deletable_dr_runs

--- a/bin/npg_status2file
+++ b/bin/npg_status2file
@@ -4,11 +4,12 @@ use strict;
 use warnings;
 use FindBin qw($Bin);
 use lib ( -d "$Bin/../lib/perl5" ? "$Bin/../lib/perl5" : "$Bin/../lib" );
-use Carp;
 use Getopt::Long;
 use Pod::Usage;
+use Log::Log4perl qw{:levels};
 
 use npg_tracking::status;
+use npg_tracking::Schema;
 
 our $VERSION = '0';
 
@@ -16,17 +17,26 @@ my $dir_out;
 my $id_run;
 my @lanes = ();
 my $status;
+my $db_flag;
 GetOptions('dir_out=s' => \$dir_out,
            'id_run=i'  => \$id_run,
            'status=s'  => \$status,
            'lanes=i@'  => \@lanes,
+           'db_save'   => \$db_flag,
           ) || pod2usage(2);
 
+my $layout = '%d %-5p %c - %m%n';
+Log::Log4perl->easy_init({layout => $layout,
+                          level  => $INFO,
+                          utf8   => 1});
+my $logger = Log::Log4perl->get_logger();
+
 if (!$dir_out) {
-  croak '--dir_out option should be set';
+  $logger->error_die('--dir_out option should be set');
 }
 if ( !(-d $dir_out && -w $dir_out) ) {
-  croak "--dir_out option $dir_out should be a writable directory";
+  $logger->error_die(
+    "--dir_out option $dir_out should be a writable directory");
 }
 
 #####
@@ -35,10 +45,17 @@ if ( !(-d $dir_out && -w $dir_out) ) {
 # inambigiously. 
 sleep 2;
 
-my $path = npg_tracking::status->new(
-   id_run => $id_run, status => $status, lanes => \@lanes)->to_file($dir_out);
+my $status_obj = npg_tracking::status->new(
+   id_run => $id_run, status => $status, lanes => \@lanes);
+my $path = $status_obj->to_file($dir_out);
+$logger->info("Wrote status '$status' to $path");
 
-warn "Wrote status '$status' to $path\n";
+if ($db_flag) {
+  $logger->info("Saving status '$status' to the database"); 
+  $status_obj->to_database(npg_tracking::Schema->connect());
+} else {
+  $logger->info("Not saving status '$status' to the database");
+}
 
 0;
 
@@ -51,13 +68,19 @@ npg_status2file
 =head1 USAGE
 
   #save status for two lanes
-  npg_status2file --id_run 1234 --lanes 1 --lanes 2  --dir_out my_dir --status 'qc review pending'
+  npg_status2file --id_run 1234 --lanes 1 --lanes 2  --dir_out my_dir \
+    --status 'qc review pending'
 
   #save status for one lane
-  npg_status2file --id_run 1234 --lanes 1 --dir_out my_dir --status 'analysis in progress'
+  npg_status2file --id_run 1234 --lanes 1 --dir_out my_dir \
+    --status 'analysis in progress'
 
   #save status for a run
   npg_status2file --id_run 1234 --dir_out my_dir --status 'analysis pending'
+
+  #save status for a run and create a database record
+  npg_status2file --id_run 1234 --dir_out my_dir --db_save \
+    --status 'analysis pending'
 
 =head1 REQUIRED ARGUMENTS
 
@@ -67,7 +90,10 @@ npg_status2file
 
 =head1 OPTIONS
 
- If --lanes exist then one lane status json file is created to cover all lanes.
+If --db_save is enabled, in addition to saving the status in a JSON file,
+the status record is created in the tracking database.
+
+If --lanes is set then one lane status JSON file is created to cover all lanes.
 
 =head1 EXIT STATUS
 
@@ -77,8 +103,9 @@ npg_status2file
 
 =head1 DESCRIPTION
 
- Given run identifier, an optional array of lanes, the status description
- and output directory, creates a json file recording the input plus a timestamp.
+Given run identifier, an optional array of lanes, the status description
+and output directory, creates a json file recording the input plus a timestamp.
+Optionally creates a run or lane status record in the tracking database.
 
 =head1 DIAGNOSTICS
 
@@ -92,11 +119,13 @@ npg_status2file
 
 =item warnings
 
-=item Carp
-
 =item Getopt::Long
 
+=item Log::Log4perl
+
 =item npg_pipeline::status
+
+=item npg_tracking::Schema
 
 =item FindBin
 
@@ -112,11 +141,17 @@ npg_status2file
 
 =head1 AUTHOR
 
-Kate Taylor
+=over
+
+=item Kate Taylor
+
+=item Marina Gourtovaia
+
+=back
 
 =head1 LICENSE AND COPYRIGHT
 
-Copyright (C) 2014 Genome Research Limited
+Copyright (C) 2014,2019,2021 Genome Research Ltd.
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/bin/npg_status_save
+++ b/bin/npg_status_save
@@ -47,8 +47,6 @@ sleep 2;
 
 my $status_obj = npg_tracking::status->new(
    id_run => $id_run, status => $status, lanes => \@lanes);
-my $path = $status_obj->to_file($dir_out);
-$logger->info("Wrote status '$status' to $path");
 
 if ($db_flag) {
   $logger->info("Saving status '$status' to the database"); 
@@ -56,6 +54,9 @@ if ($db_flag) {
 } else {
   $logger->info("Not saving status '$status' to the database");
 }
+
+my $path = $status_obj->to_file($dir_out);
+$logger->info("Wrote status '$status' to $path");
 
 0;
 

--- a/bin/npg_status_save
+++ b/bin/npg_status_save
@@ -63,23 +63,23 @@ __END__
 
 =head1 NAME
 
-npg_status2file
+npg_status_save
 
 =head1 USAGE
 
   #save status for two lanes
-  npg_status2file --id_run 1234 --lanes 1 --lanes 2  --dir_out my_dir \
+  npg_status_save --id_run 1234 --lanes 1 --lanes 2  --dir_out my_dir \
     --status 'qc review pending'
 
   #save status for one lane
-  npg_status2file --id_run 1234 --lanes 1 --dir_out my_dir \
+  npg_status_save --id_run 1234 --lanes 1 --dir_out my_dir \
     --status 'analysis in progress'
 
   #save status for a run
-  npg_status2file --id_run 1234 --dir_out my_dir --status 'analysis pending'
+  npg_status_save --id_run 1234 --dir_out my_dir --status 'analysis pending'
 
   #save status for a run and create a database record
-  npg_status2file --id_run 1234 --dir_out my_dir --db_save \
+  npg_status_save --id_run 1234 --dir_out my_dir --db_save \
     --status 'analysis pending'
 
 =head1 REQUIRED ARGUMENTS

--- a/t/10-npg_tracking-status.t
+++ b/t/10-npg_tracking-status.t
@@ -1,9 +1,12 @@
 use strict;
 use warnings;
-use Test::More tests => 28;
+use Test::More tests => 7;
 use Test::Exception;
 use File::Temp qw/ tempdir /;
 use Cwd;
+use Log::Log4perl qw(:levels);
+use List::MoreUtils qw/uniq/;
+use t::dbic_util;
 
 use_ok(q{npg_tracking::status});
 
@@ -11,8 +14,11 @@ my $id_run = 1234;
 my $status = q{analysis in progress};
 my $dir = tempdir(UNLINK => 1);
 my $current = getcwd();
+my $schema = t::dbic_util->new()->test_schema();
 
-{ 
+subtest 'create object' => sub {
+  plan tests => 2;
+  
   my $rls = npg_tracking::status->new(
       id_run => $id_run,
       lanes => [1],
@@ -22,9 +28,11 @@ my $current = getcwd();
   like( $rls->timestamp,
     qr{\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\+\d\d\d\d},
     'timestamp generated');
-}
+};
 
-{
+subtest 'multiple lanes status - JSON serialization' => sub {
+  plan tests => 11;
+
   my @lanes = (7, 6, 5);
   my $rls = npg_tracking::status->new(
     id_run => $id_run,
@@ -49,11 +57,14 @@ my $current = getcwd();
   $filename = join(q[/], $dir, $filename);
   ok(-e $filename, 'file exists');
   my $new;
-  lives_ok { $new = npg_tracking::status->from_file($filename)  } 'object read from  file';
+  lives_ok { $new = npg_tracking::status->from_file($filename)  }
+    'object read from  file';
   isa_ok($new, q{npg_tracking::status});
-}
+};
 
-{
+subtest 'single lanes status - JSON serialization' => sub {
+  plan tests => 7;
+
   my @lanes = (1);
 
   my $rls = npg_tracking::status->new(
@@ -74,9 +85,11 @@ my $current = getcwd();
   is ($o->status, $status, 'status correct');
   is ($o->id_run, $id_run, 'run id correct');
   is_deeply($o->lanes, \@lanes, 'lanes array correct');
-}
+};
 
-{
+subtest 'single lanes status - JSON serialization' => sub {
+  plan tests => 7;
+
   my $status = q{analysis complete};
 
   my $rls = npg_tracking::status->new(
@@ -97,7 +110,112 @@ my $current = getcwd();
   my $path = $o->to_file();
   ok(-e $path, 'file created in current directory');
   chdir $current;
-}
+};
+
+subtest 'saving status to a database - errors' => sub {
+  plan tests => 6;
+
+  my $s = npg_tracking::status->new(id_run => 9999, status => 'some status');
+  throws_ok {$s->to_database()}
+    qr/Tracking database DBIx schema object is required/,
+    'database handle is required';
+  throws_ok {$s->to_database($schema)} qr/Run id 9999 does not exist/,
+    'error saving status for non-existing run';
+  $s = npg_tracking::status->new(id_run => 1, status => 'some status');
+  throws_ok {$s->to_database($schema)}
+    qr/Status 'some status' does not exist in RunStatusDict /,
+    'error saving non-existing run status';
+  $s = npg_tracking::status->new(
+    id_run => 1, status => 'some status', timestamp => 'some time');
+  throws_ok {$s->to_database($schema)}
+    qr/Your datetime does not match your pattern/,
+    'error converting timestamp to an object';
+  $s = npg_tracking::status->new(
+    id_run => 1, status => 'some status', lanes => [8, 7, 3]);
+  throws_ok {$s->to_database($schema)} qr/Lane 3 does not exist in run 1/,
+    'error saving status for a list of lanes that includes non-existing lane';
+  $s = npg_tracking::status->new(
+    id_run => 1, status => 'some status', lanes => [8, 7]);
+  throws_ok {$s->to_database($schema)}
+    qr/Status 'some status' does not exist in RunLaneStatusDict/,
+    'error saving non-existing lane status';
+};
+
+subtest 'saving status to a database' => sub {
+  plan tests => 14;
+
+  Log::Log4perl->easy_init({layout => '%d %-5p %c - %m%n',
+                            level  => $DEBUG,
+                            file   => join(q[/], $dir, 'logfile'),
+                            utf8   => 1});
+  my $logger = Log::Log4perl->get_logger();  
+
+  my $id_run = 9334;
+  $schema->resultset('Run')->create({id_run        => $id_run,
+                                     id_instrument => 48,
+                                     team          => 'A'});
+  foreach my $lane ((1 .. 4)) {
+    $schema->resultset('RunLane')->create({id_run   => $id_run,
+                                           position => $lane});
+  }
+
+  my @status_objs =
+    map { npg_tracking::status->new(id_run => $id_run, status => $_) }
+    ('analysis in progress', 'secondary analysis in progress');
+  my $srs = $schema->resultset('RunStatus')->search({id_run => $id_run});
+  $srs->delete;
+  $schema->resultset('RunLaneStatus')->search({})->delete();
+
+  $status_objs[0]->to_database($schema);
+  my $rs = $srs->search({iscurrent => 1})->next()->run_status_dict;
+  is ($rs->description(), 'analysis in progress', 'run status reset');
+
+  $status_objs[1]->to_database($schema, $logger);
+  $rs = $srs->search({iscurrent => 1})->next()->run_status_dict;
+  is ($rs->description(), 'secondary analysis in progress', 'run status reset');
+  $status_objs[1]->to_database($schema, $logger);
+  $rs = $srs->search({iscurrent => 1})->next()->run_status_dict;
+  is ($rs->description(), 'secondary analysis in progress',
+    'run status not reset');
+
+  is ($schema->resultset('RunLaneStatus')->search({})->count(), 0,
+    'no lane status records are created');
+
+  $schema->resultset('RunStatus')->search({})->delete();
+
+  my $status_desc = 'analysis in progress';
+  my $status_obj = npg_tracking::status->new(
+    id_run => $id_run, status => $status_desc, lanes => [1,3]);
+  $status_obj->to_database($schema);
+  my @rl_statuses = $schema->resultset('RunLaneStatus')->search({})->all();
+  is(scalar @rl_statuses, 2, 'two lane status records are created');
+  my @descriptions = uniq map { $_->description } @rl_statuses;
+  is (scalar @descriptions, 1, 'one unique status description');
+  is ($descriptions[0], $status_desc, 'correct lane statuses are created');
+  
+  $status_desc = 'analysis complete';
+  $status_obj = npg_tracking::status->new(
+    id_run => $id_run, status => $status_desc, lanes => [1,2,3]);
+  $status_obj->to_database($schema, $logger);
+  is ($schema->resultset('RunLaneStatus')->search({})->count(), 5,
+    'five lane status records in total');
+  @rl_statuses = $schema->resultset('RunLaneStatus')
+    ->search({iscurrent => 1})->all();
+  is(scalar @rl_statuses, 3, 'three current lane status records');
+  @descriptions = uniq map { $_->description } @rl_statuses;
+  is (scalar @descriptions, 1, 'one unique status description'); 
+  is ($descriptions[0], $status_desc, 'correct lane statuses are created');
+    
+  $status_obj->to_database($schema, $logger);
+  @rl_statuses = $schema->resultset('RunLaneStatus')
+    ->search({iscurrent => 1})->all();
+  @descriptions = uniq map { $_->description } @rl_statuses;
+  is (scalar @descriptions, 1, 'one unique status description');
+  is ($descriptions[0], $status_desc, 'correct lane statuses are created');
+
+  is ($schema->resultset('RunStatus')->search({})->count(), 0,
+    'no run status records are created') ;  
+};
 
 END {
   eval {chdir $current};

--- a/t/70-bin-npg_status2file.t
+++ b/t/70-bin-npg_status2file.t
@@ -5,7 +5,7 @@ use Test::More tests => 12;
 use File::Temp qw{ tempdir };
 
 my $tempdir = tempdir(CLEANUP => 1,);
-my $script = 'bin/npg_status2file';
+my $script = 'bin/npg_status_save';
 
 use_ok(q{npg_tracking::status});
 


### PR DESCRIPTION
The status monitor is going to be decomissioned in favour of saving
statuses to the database by pipeline jobs. We'd like to maintain an
ability to cteate JSON files with statuses, so the npg_status2file script
is extended to optionally save the status to a database.

When the pipeline is changed to use the new `--db_save` option, we might need to temporarily comment out JSON file creation so that the status daemon, which will have to run for some time after the change is introduced is not creating  superfluous database entries.

