### PR TITLE
Custom location of the Clearpress configuration file for unit tests.

### DIFF
--- a/Changes
+++ b/Changes
@@ -3,6 +3,10 @@ LIST OF CHANGES
  - Remove live tests for st::api::lims XML driver and other XML-based APIs.
    The CI tests are mostly run on hosts with no access to either production
    or development hosts. 
+ - NPG_TEST_TRACKING_CONFIGPATH environment variable can be used to set a
+   custom location of the Clearpress configuration file for unit tests.
+   The default location of the file, data/config.ini, is used if the
+   variable is unset. 
 
 release 91.13.0
  - Extend npg_status2file script to optionally save statuses to the tracking

--- a/t/util.pm
+++ b/t/util.pm
@@ -2,10 +2,7 @@ package t::util;
 
 use strict;
 use warnings;
-use base qw(npg::util Exporter);
-use t::dbh;
 use Carp;
-use npg::model::user;
 use DateTime;
 use CGI;
 use English qw(-no_match_vars);
@@ -17,11 +14,40 @@ use MIME::Lite;
 use GD;
 use Readonly;
 
+# Inherit from npg::util, which, in turn, inherits from Clearpress::util
+use base qw(npg::util Exporter);
+
+use npg::model::user;
+use t::dbh;
+
 Readonly::Scalar our $DEFAULT_FIXTURES_PATH => q[t/data/fixtures];
 
 $ENV{HTTP_HOST}     = 'test.npg.com';
 $ENV{SCRIPT_NAME}   = '/cgi-bin/npg';
 $ENV{dev}           = 'test';
+
+sub configpath { # Overwrites parent's method of the same name.
+                 # A full path to the Clearpress-style configuration file
+                 # with database credentials.
+  my $self = shift;
+
+  if (!$self->{configpath}) {
+    # Use a custom path or whatever is used by the parent.
+    my $given_path = $ENV{'NPG_TEST_TRACKING_CONFIGPATH'} ||
+                     $self->SUPER::configpath();
+    my ($path) = $given_path =~ m{([a-z0-9/\._\-]+)}ixms;
+    (defined $path) or $path = q[];
+    ($path eq $given_path) or carp
+      "Conf. path '$given_path' is changed to '$path' after de-tainting";
+    -e $path or croak "ERROR: Conf. path '$path' does not exist";
+    -d $path and croak
+      "ERROR: Conf. path '$path' is a directory, should be a file";
+    -r $path or croak "ERROR: Conf. path '$path' is not readable";
+    $self->{configpath} = $path;
+  }
+
+  return $self->{configpath};
+}
 
 sub dbh {
   my ($self, @args) = @_;
@@ -173,15 +199,14 @@ sub requestor {
     $self->{requestor} = $req;
   } elsif($req) {
     $self->{requestor} = npg::model::user->new({
-						util     => $self,
-						username => $req,
-					       });
+            util     => $self,
+            username => $req,});
   }
 
   $self->{requestor} ||= npg::model::user->new({
-						util     => $self,
-						username => 'public',
-					       });
+            util     => $self,
+            username => 'public',});
+
   return $self->{requestor};
 }
 
@@ -268,16 +293,16 @@ sub parse_html_to_get_expected {
 
   if ($html =~ m{^t/}xms) {
     $p = HTML::PullParser->new(
-			       file  => $html,
-			       start => '"S", tagname, @attr',
-			       end   => '"E", tagname',
-			      );
+             file  => $html,
+             start => '"S", tagname, @attr',
+             end   => '"E", tagname',
+         );
   } else {
     $p = HTML::PullParser->new(
-			       doc   => $html,
-			       start => '"S", tagname, @attr',
-			       end   => '"E", tagname',
-			      );
+            doc   => $html,
+            start => '"S", tagname, @attr',
+            end   => '"E", tagname',
+         );
   }
 
   my $count = 1;
@@ -342,7 +367,6 @@ sub catch_email {
 ##########
 # for parsing emails to get information from them, probably caught emails
 #
-
 sub parse_email {
   my ($self, $email, $for_mailer) = @_;
   my $parser = MIME::Parser->new();
@@ -350,13 +374,13 @@ sub parse_email {
   my $entity = $parser->parse_data($email);
   if(! $entity->bodyhandle->as_string() ) {return {};}
   my $ref    = {
-		annotation => $entity->bodyhandle->as_string(),
-		subject    => $entity->head->get('Subject', 0),
-		to         => $entity->head->get('To',0)   || undef,
-		cc         => $entity->head->get('Cc',0)   || undef,
-		bcc        => $entity->head->get('Bcc',0)  || undef,
-		from       => $entity->head->get('From',0) || undef,
-	       };
+    annotation => $entity->bodyhandle->as_string(),
+    subject    => $entity->head->get('Subject', 0),
+    to         => $entity->head->get('To',0)   || undef,
+    cc         => $entity->head->get('Cc',0)   || undef,
+    bcc        => $entity->head->get('Bcc',0)  || undef,
+    from       => $entity->head->get('From',0) || undef,
+  };
   if ($for_mailer) {
     $ref->{body}          = $entity->bodyhandle->as_string()     || undef;
     $ref->{precendence}   = $entity->head->get('Precedence',0)   || undef;


### PR DESCRIPTION
NPG_TEST_TRACKING_CONFIGPATH environment variable can be used to set
a custom location of the Clearpress configuration file for unit tests.
If this variable is unset, a default location of the configuration
is used.

This functionality will be used when running a full stack tests when we do not have a direct access to tracking conf file for tests. Password-less MySQL access for a root is not encouraged these days.