### PR TITLE
Block access to tsv files via httpd_sfweb.conf

### DIFF
--- a/Changes
+++ b/Changes
@@ -11,6 +11,7 @@ LIST OF CHANGES
    describing environment variables and tags.
  - Move db schema dump, which is only used for tests, from tge data to t/data
    directory.
+ - Block access to tsv files via httpd_sfweb.conf
 
 release 91.13.0
  - Extend npg_status2file script to optionally save statuses to the tracking

--- a/wtsi_local/httpd_sfweb.conf
+++ b/wtsi_local/httpd_sfweb.conf
@@ -26,7 +26,7 @@ Alias "/export"   "/export"
 # Disable access to (download of) some files.
 # Does not prevent them being listed in the directory view above.
 #
-<FilesMatch "\.(cif|dif|cbcl|bcl|ba[im]|sam|fa(stq)?|fq|cra[im]|bed(pe)?|vcf|geno)(\.(gz|xz|bz2))?$">
+<FilesMatch "\.(cif|dif|cbcl|bcl|ba[im]|sam|fa(stq)?|fq|cra[im]|bed(pe)?|vcf|geno|tsv)(\.(gz|xz|bz2))?$">
     Require             all denied
 </FilesMatch>
 


### PR DESCRIPTION
As suggested by dj3 it would be best to compile a whitelist but in the meantime block tsv files (artic pp pipeline variant files).