### PR TITLE
remove collocation checks for staging area links

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -210,7 +210,6 @@ my $builder = $class->new(
                 'Template'                        => '2.19',
                 'Try::Tiny'                       => 0,
                 'URI::Escape'                     => 0,
-                'URI::URL'                        => 0,
                 'utf8'                            => 0,
                 'warnings'                        => '1.05',
                 'XML::LibXML'                     => '1.70',

--- a/Changes
+++ b/Changes
@@ -1,5 +1,9 @@
 LIST OF CHANGES
 
+ - Removed colocation functionality in npg_tracking views. Colocation checks
+   will not make sense once npg_tracking runs in containers in head nodes.
+   Staging areas are not local to head node/reachable from within the
+   container.
  - Removed old team names from run add template
  - Made NovaSeq instruments skip wash statuses after completing a run, this
    does not affect statuses set manually through the UI.

--- a/lib/npg/view.pm
+++ b/lib/npg/view.pm
@@ -3,7 +3,6 @@ package npg::view;
 use strict;
 use warnings;
 use POSIX qw(strftime);
-use URI::URL;
 use Carp;
 use Try::Tiny;
 
@@ -288,8 +287,6 @@ residing on staging areas.
 =item Carp
 
 =item Try::Tiny
-
-=item URI::URL
 
 =item strict
 

--- a/lib/npg/view.pm
+++ b/lib/npg/view.pm
@@ -164,15 +164,6 @@ sub staging_urls {
   my $tracking_key = 'npg_tracking';
 
   my $surl = $config->{$tracking_key};
-  $surl ||= q{};
-  # If the host that has access to a staging area and
-  # this host (the host this request went to) are located
-  # in the same cluster, this host is likely to have
-  # access to that staging area itself. Therefore, a
-  # separate url is not needed. It is important that the
-  # development servers serve all urls themselves and
-  # do not delegate some urls to production servers.
-  $surl = ($surl && $self->_colocated($surl)) ? q{} : $surl;
   if (!$surl) {
     delete $config->{$tracking_key};
   }
@@ -198,25 +189,6 @@ sub staging_urls {
 sub lims_batches_url {
   my $self = shift;
   return $self->util->lims_url . '/batches/';
-}
-
-sub _colocated {
-  my ($self, $staging_url) = @_;
-  my $request_cluster = $self->_cluster(
-    $self->util()->cgi()->url(-full => 1));
-  my $staging_cluster = $self->_cluster($staging_url);
-  return $request_cluster && $staging_cluster &&
-         ($request_cluster eq $staging_cluster);
-}
-
-sub _cluster {
-  my ($self, $url) = @_;
-  # Expect url to be host.cluster.sanger.ac.uk,
-  # but do not fail if it's something else.
-  # Return cluster name or the original url/IP address.
-  $url = URI::URL->new($url)->host();
-  $url=~ s/\A[^\.]+\.//smx;
-  return $url;
 }
 
 1;


### PR DESCRIPTION
After moving npg_tracking to containers in head nodes and once staging areas
are not local to head nodes, the check is not valid anymore. We expect staging
areas will be independent of farm head nodes (different filesystem) and we are
not allowing the container to access local filesystems where staging areas
would be.