### PR TITLE
Restrict web server directory views to /export

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 LIST OF CHANGES
 
+ - Removed ability of the tracking server to provide directory views of
+   visible to the server /nfs partitions since nfs staging servers are
+   no longer used.
  - Removed colocation functionality in npg_tracking views. Colocation checks
    will not make sense once npg_tracking runs in containers in head nodes.
    Staging areas are not local to head node/reachable from within the

--- a/wtsi_local/httpd_sfweb.conf
+++ b/wtsi_local/httpd_sfweb.conf
@@ -10,9 +10,8 @@ CGIDScriptTimeout 100
 #
 # Make staging directories content visible to this server
 #
-Alias "/nfs"      "/nfs"
 Alias "/export"   "/export"
-<DirectoryMatch "^/(nfs|export)/(sf|gs|esa-sv-[0-9]+-)[0-9]+" >
+<DirectoryMatch "^/export/esa-sv-[0-9]+-[0-9]+" >
     Options		Includes Indexes FollowSymLinks
     IndexOptions	FancyIndexing XHTML NameWidth=* 
     IndexOptions	ShowForbidden SuppressDescription SuppressIcon


### PR DESCRIPTION
Removed ability of the tracking server to provide directory
views of visible to the server /nfs partitions since nfs
staging servers are no longer used.