### PR TITLE
Fix broken libGD package in CI

### DIFF
--- a/.github/workflows/testing_and_building_repos.yml
+++ b/.github/workflows/testing_and_building_repos.yml
@@ -42,7 +42,7 @@ jobs:
     #install libgd-dev and uuid-dev
     - name: install libgd-dev and uuid-dev 
       run:
-          sudo apt-get install -y libgd-dev uuid-dev 
+          sudo apt-get update -y && sudo apt-get install -y libgd-dev uuid-dev 
     
     - name: install cpanm
       run: |

--- a/.github/workflows/testing_and_building_repos.yml
+++ b/.github/workflows/testing_and_building_repos.yml
@@ -42,7 +42,7 @@ jobs:
     #install libgd-dev and uuid-dev
     - name: install libgd-dev and uuid-dev 
       run:
-          sudo apt-get update -y && sudo apt-get install -y libgd-dev uuid-dev 
+          sudo apt-get update -y && sudo apt-get install -y libgd-dev uuid-dev libgd-text-perl
     
     - name: install cpanm
       run: |


### PR DESCRIPTION
Run `apt-get update` to ensure apt doesn't fetch a nonexistent package. Also add `libgd-text-perl` which isn't included in `libgd-dev` anymore.