### PR TITLE
Simplified run complete and mirrored detection.

### DIFF
--- a/bin/staging_area_monitor
+++ b/bin/staging_area_monitor
@@ -135,8 +135,7 @@ sub check_path { ##### Function to deal with one run folder
             $folder->update_run_record(); # Inspect and update cycles,
                                           # including expected cycle count!
 
-            if ( $folder->mirroring_complete($run_path) &&
-                 $folder->check_tiles($run_path) ) {
+            if ( $folder->check_tiles($run_path) ) {
 
                 my $previous_size = $previous_size_of->{$run_path};
                 my ( $current_size, $latest_mod ) = $folder->monitor_stats();


### PR DESCRIPTION
Removed exessive complexity in finding RTACpmplete.txt and CopyComplete.txt files.

Removed a second round of examining the above files at the stage of deciding whether the mirroring has been completed.

Removed examination of the content of the Error log file since it is not present in the runfolders created by the contemporary instruments.