### PR TITLE
Reimplemented waiting for the onboard analysis.

### DIFF
--- a/bin/staging_area_monitor
+++ b/bin/staging_area_monitor
@@ -160,7 +160,7 @@ sub check_path { ##### Function to deal with one run folder
 
                 # Check if we are waiting for the onboard analysis to finish.
                 if ($folder->is_onboard_analysis_planned() &&
-                    !$folder->has_onboard_analysis_finished()) {
+                    !$folder->is_onboard_analysis_output_copied()) {
                     return;
                 }
 

--- a/lib/Monitor/RunFolder/Staging.pm
+++ b/lib/Monitor/RunFolder/Staging.pm
@@ -30,6 +30,13 @@ Readonly::Scalar my $MODE_INDEX           => 2;
 
 Readonly::Scalar my $RTA_COMPLETE_FN      => q[RTAComplete.txt];
 Readonly::Scalar my $COPY_COMPLETE_FN     => q[CopyComplete.txt];
+Readonly::Scalar my $DEFAULT_ONBOARD_ANALYSIS_DN => q[1];
+# The file with the name below flags the completion of a particular
+# DRAGEN analysys. However, it's the CopyComplete.txt file in the particular
+# analysis directory (/Analysis/1/, /Analysis/2/, etc.) that flags the
+# completion of the analysis output to staging. In future we might track
+# the DRAGEN analysis timeline, so keep this variable, though it is not
+# used at the moment.
 Readonly::Scalar my $ONBOARD_ANALYSIS_COMPLETE_FN =>
                                              q[Secondary_Analysis_Complete.txt];
 Readonly::Scalar my $ONBOARD_ANALYSIS_SAMPLESHEET_FN => q[SampleSheet.csv]; 
@@ -107,13 +114,15 @@ sub is_onboard_analysis_planned {
     return $planned;
 }
 
-sub has_onboard_analysis_finished {
+sub is_onboard_analysis_output_copied {
+
     my $self = shift;
 
     my $analysis_dir = $self->dragen_analysis_path();
     my $found = 0;
     if (-d $analysis_dir) {
-        my $file = join q[/], $analysis_dir, $ONBOARD_ANALYSIS_COMPLETE_FN;
+        my $file = join q[/], $analysis_dir,
+                              $DEFAULT_ONBOARD_ANALYSIS_DN, $COPY_COMPLETE_FN;
         $found = -f $file;
         carp sprintf '%s is%sfound', $file, $found ? q[ ] : q[ not ];         
     } else {
@@ -415,10 +424,11 @@ Returns true if the run folder for the NovaSeq SeriesX run contains a
 samplesheet with a section for the bcl on board data conversion. Always returns
 false for other instrument types.
 
-=head2 has_onboard_analysis_finished
+=head2 is_onboard_analysis_output_copied
 
-Returns true if the file that inticates that the onboard analysis has finished
-is present in the run folder.
+Returns true if the file that flags the end of the transfer of the onboard
+analysis output to staging is present in the default DRAGEN analysis directory
+([RUNFOLDER_NAME]/Analysis/1/ at the moment).
 
 =head1 CONFIGURATION AND ENVIRONMENT
 

--- a/t/34-monitor-runfolder-staging.t
+++ b/t/34-monitor-runfolder-staging.t
@@ -465,7 +465,7 @@ subtest 'run completion for NovaSeqX' => sub {
 };
 
 subtest 'onboard analysis completion for NovaSeqX' => sub {
-    plan tests => 6;
+    plan tests => 8;
 
     my $tmpdir = tempdir( CLEANUP => 1 );
     copy('t/data/run_params/RunParameters.novaseqx.xml',"$tmpdir/RunParameters.xml")
@@ -477,8 +477,8 @@ subtest 'onboard analysis completion for NovaSeqX' => sub {
     
     ok (!$monitor->is_onboard_analysis_planned(),
         'onboard analysis is not planned');
-    ok (!$monitor->has_onboard_analysis_finished(),
-        'onboard analysis has not finished');
+    ok (!$monitor->is_onboard_analysis_output_copied(),
+        'onboard analysis has not been copied');
 
     my $ss_file = "$tmpdir/SampleSheet.csv";
     open my $fh, '>', $ss_file or die 'Cannot open a file for writing';
@@ -487,18 +487,27 @@ subtest 'onboard analysis completion for NovaSeqX' => sub {
     ok (!$monitor->is_onboard_analysis_planned(),
         'onboard analysis is not planned');
 
-    mkdir "$tmpdir/Analysis";
-    ok (!$monitor->has_onboard_analysis_finished(),
-        'onboard analysis has not finished');
-
+    my $adir = "$tmpdir/Analysis";
+    mkdir $adir;
+    ok (!$monitor->is_onboard_analysis_output_copied(),
+        'onboard analysis has not been copied');
+    
     open $fh, '>>', $ss_file or die 'Cannot open a file for appending';
     print $fh "[BCLConvert_Settings]\n" or die 'Cannot print';
     close $fh or die 'Cannot close the file handle';
     ok ($monitor->is_onboard_analysis_planned(), 'onboard analysis is planned');
+    ok (!$monitor->is_onboard_analysis_output_copied(),
+        'onboard analysis has not been copied');
+    
+    mkdir "$adir/2"; 
+    `touch $adir/2/CopyComplete.txt`;
+    ok (!$monitor->is_onboard_analysis_output_copied(),
+        'onboard analysis has not been copied');
 
-    `touch $tmpdir/Analysis/Secondary_Analysis_Complete.txt`;
-    ok ($monitor->has_onboard_analysis_finished(),
-        'onboard analysis has finished');     
+    mkdir "$adir/1";
+    `touch $adir/1/CopyComplete.txt`;
+    ok ($monitor->is_onboard_analysis_output_copied(),
+      'onboard analysis has been copied');     
 };
 
 subtest 'no onboard analysis planned for NovaSeq' => sub {


### PR DESCRIPTION
Previously we were looking at the wrong file in the wrong place. Now we are waiting for the output of the onboard analysis to be copied to staging. This is a step towards declaring the run as mirrored.