### PR TITLE
update httpd.conf with new values for mpm event

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,7 @@
 LIST OF CHANGES
 
+ - update httpd.conf with new values for mpm event
+
 release 97.0.0
  - Change CI workflow to standard file name
  - Change to Perl versions from Perlbrew

--- a/wtsi_local/httpd.conf
+++ b/wtsi_local/httpd.conf
@@ -155,13 +155,18 @@ Group ${APACHE_RUN_GROUP}
 </IfModule>
 
 <IfModule mpm_event_module>
-    StartServers            5
-    MinSpareThreads         5
-    MaxSpareThreads        10
-    ServerLimit            50
-    ThreadsPerChild         1
-    MaxRequestWorkers      50
-    MaxConnectionsPerChild 50
+    KeepAlive                On
+    KeepAliveTimeout          5
+    MaxKeepAliveRequests    128
+
+    ServerLimit              15
+    StartServers              5
+    ThreadLimit             128
+    ThreadsPerChild         128
+    MaxRequestWorkers      1280
+    MinSpareThreads         256
+    MaxSpareThreads         512
+    MaxConnectionsPerChild 2048
 </IfModule>
 
 


### PR DESCRIPTION
Previous values were causing issues in Jammy. New values use more resources but service is more stable.

Originally found at:

https://dev.to/joetancy/php-fpm-with-apache2-2mk0
https://thecustomizewindows.com/2023/04/how-to-install-apache-mpm-worker-and-php-fpm-on-ubuntu-server/