### PR TITLE
Restricted automatically meargeable to NovaSeq.

### DIFF
--- a/lib/npg_tracking/illumina/run/long_info.pm
+++ b/lib/npg_tracking/illumina/run/long_info.pm
@@ -654,17 +654,14 @@ sub _build_sbs_consumable_version {
 
 =head2 all_lanes_mergeable
 
-Returns true if either the NovaSeq Standard (ie not NovaSeqXp) workflow
-was used or this was a rapid run since in the latter case same library is used
-on both lanes.
+Returns true if the NovaSeq Standard (ie not NovaSeqXp) workflow was used
+since it is guaranteed that the same library is used on all lanes.
 
 =cut
 
 sub all_lanes_mergeable {
   my $self = shift;
-  return (
-    ($self->workflow_type() =~ /NovaSeqStandard/xms) or $self->is_rapid_run()
-         );
+  return ($self->workflow_type() =~ /NovaSeqStandard/xms);
 }
 
 =head2 is_rapid_run

--- a/t/60-illumina-run-long_info.t
+++ b/t/60-illumina-run-long_info.t
@@ -88,7 +88,7 @@ subtest 'retrieving information from runParameters.xml' => sub {
 
     if ($f =~ /\.rr\./) {
       ok ($li->is_rapid_run(), 'is rapid run');
-      ok ($li->all_lanes_mergeable(), 'all lanes meargeable');
+      ok (!$li->all_lanes_mergeable(), 'lanes are not meargeable');
       if ($f =~ /\.truseq\./) {
         ok (!$li->is_rapid_run_v2(), 'rapid run version is not 2');
         ok ($li->is_rapid_run_v1(), 'rapid run version is 1');

--- a/t/60-illumina-run-long_info.t
+++ b/t/60-illumina-run-long_info.t
@@ -88,7 +88,7 @@ subtest 'retrieving information from runParameters.xml' => sub {
 
     if ($f =~ /\.rr\./) {
       ok ($li->is_rapid_run(), 'is rapid run');
-      ok (!$li->all_lanes_mergeable(), 'lanes are not meargeable');
+      ok (!$li->all_lanes_mergeable(), 'lanes are not mergeable');
       if ($f =~ /\.truseq\./) {
         ok (!$li->is_rapid_run_v2(), 'rapid run version is not 2');
         ok ($li->is_rapid_run_v1(), 'rapid run version is 1');
@@ -101,10 +101,10 @@ subtest 'retrieving information from runParameters.xml' => sub {
       ok (!$li->is_rapid_run(), 'is not rapid run');
       if ($f =~ /\.novaseq\./) {
         if ($f =~ /\.xp\./) {
-          ok (!$li->all_lanes_mergeable(), 'lanes are not meargeable');
+          ok (!$li->all_lanes_mergeable(), 'lanes are not mergeable');
           is ($li->workflow_type, 'NovaSeqXp', 'Xp workflow type');
         } else {
-          ok ($li->all_lanes_mergeable(), 'all lanes meargeable');
+          ok ($li->all_lanes_mergeable(), 'all lanes mergeable');
           is ($li->workflow_type, 'NovaSeqStandard', 'Standard workflow type');
         }
       }


### PR DESCRIPTION
In practice we never automatically merged rapid runs, this flag was reverted to false for them by the pipeline. Instruments on which rapid runs were performed are no longer in use.