### PR TITLE
Ability to set a path for NovaSeqX samplesheet

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -161,6 +161,7 @@ lib/npg_tracking/report/event2followers.pm
 lib/npg_tracking/report/event2subscribers.pm
 lib/npg_tracking/report/events.pm
 lib/npg/samplesheet.pm
+lib/npg/samplesheet/base.pm
 lib/npg/samplesheet/novaseq_xseries.pm
 lib/npg/samplesheet/auto.pm
 lib/npg/util.pm

--- a/lib/npg/samplesheet/base.pm
+++ b/lib/npg/samplesheet/base.pm
@@ -210,7 +210,7 @@ __END__
 
 =item npg_tracking::Schema
 
-=item  st::api::lims
+=item st::api::lims
 
 =item npg_tracking::glossary::run
 

--- a/lib/npg/samplesheet/base.pm
+++ b/lib/npg/samplesheet/base.pm
@@ -8,7 +8,6 @@ use MooseX::Getopt::Meta::Attribute::Trait::NoGetopt;
 
 use npg_tracking::Schema;
 use st::api::lims;
-use npg_tracking::util::config qw(get_config_staging_areas);
 use WTSI::DNAP::Warehouse::Schema;
 
 with 'npg_tracking::glossary::run';
@@ -31,8 +30,7 @@ A parent class for samplesheet generator. Provides common attributes.
 
 =cut
 
-my$config=get_config_staging_areas();
-Readonly::Scalar my $SAMPLESHEET_PATH => $config->{'samplesheets'}||q(samplesheets/);
+Readonly::Scalar my $SAMPLESHEET_PATH => 'samplesheets/';
 Readonly::Scalar my $LIMS_DRIVER_TYPE => 'ml_warehouse';
 
 =head1 SUBROUTINES/METHODS
@@ -48,15 +46,8 @@ A directory where the samplesheet will be created, an optional attribute.
 has 'samplesheet_path' => (
   'isa'        => 'Str',
   'is'         => 'ro',
-  'lazy_build' => 1,
+  'default'    => $SAMPLESHEET_PATH,
 );
-sub _build_samplesheet_path {
-  if($ENV{dev} and not $ENV{dev}=~/live/smix){
-    my ($suffix) = $ENV{dev}=~/(\w+)/smix;
-    return $SAMPLESHEET_PATH . $suffix . q(/);
-  }
-  return $SAMPLESHEET_PATH;
-}
 
 
 =head2 id_run
@@ -220,8 +211,6 @@ __END__
 =item npg_tracking::Schema
 
 =item  st::api::lims
-
-=item npg_tracking::util::config
 
 =item npg_tracking::glossary::run
 

--- a/lib/npg/samplesheet/base.pm
+++ b/lib/npg/samplesheet/base.pm
@@ -1,0 +1,260 @@
+package npg::samplesheet::base;
+
+use Moose;
+use namespace::autoclean;
+use Carp;
+use Readonly;
+use MooseX::Getopt::Meta::Attribute::Trait::NoGetopt;
+
+use npg_tracking::Schema;
+use st::api::lims;
+use npg_tracking::util::config qw(get_config_staging_areas);
+use WTSI::DNAP::Warehouse::Schema;
+
+with 'npg_tracking::glossary::run';
+
+our $VERSION = '0';
+
+=head1 NAME
+
+npg::samplesheet::base
+
+=head1 SYNOPSIS
+
+=head1 DESCRIPTION
+
+A parent class for samplesheet generator. Provides common attributes.
+
+=head1 DIAGNOSTICS
+
+=head1 CONFIGURATION AND ENVIRONMENT
+
+=cut
+
+my$config=get_config_staging_areas();
+Readonly::Scalar my $SAMPLESHEET_PATH => $config->{'samplesheets'}||q(samplesheets/);
+Readonly::Scalar my $LIMS_DRIVER_TYPE => 'ml_warehouse';
+
+=head1 SUBROUTINES/METHODS
+
+=cut
+
+=head2 samplesheet_path
+
+A directory where the samplesheet will be created, an optional attribute.
+
+=cut
+
+has 'samplesheet_path' => (
+  'isa'        => 'Str',
+  'is'         => 'ro',
+  'lazy_build' => 1,
+);
+sub _build_samplesheet_path {
+  if($ENV{dev} and not $ENV{dev}=~/live/smix){
+    my ($suffix) = $ENV{dev}=~/(\w+)/smix;
+    return $SAMPLESHEET_PATH . $suffix . q(/);
+  }
+  return $SAMPLESHEET_PATH;
+}
+
+
+=head2 id_run
+
+Run ID, an optional attribute.
+
+=cut
+
+has '+id_run' => (
+  'required'   => 0,
+);
+
+
+=head2 batch_id
+
+LIMS batch ID, an optional attribute. If not set, either C<id_run> or
+C<run> attribute should be set.
+
+=cut
+
+has 'batch_id' => (
+  'isa' => 'Str|Int',
+  'is'  => 'ro',
+  'lazy_build' => 1,
+  'required'   => 0,
+);
+sub _build_batch_id {
+  my $self = shift;
+  if (!$self->id_run) {
+    croak 'Run ID is not supplied, cannot get LIMS batch ID';
+  }
+  my $batch_id = $self->run()->batch_id();
+  if (!defined $batch_id) {
+    croak 'Batch ID is not set in the database record for run ' . $self->id_run;
+  }
+
+  return $batch_id;
+}
+
+
+=head2 npg_tracking_schema
+
+An attribute, DBIx Schema object for the tracking database.
+
+=cut
+
+has 'npg_tracking_schema' => (
+  'isa'        => 'npg_tracking::Schema',
+  'traits'     => [ 'NoGetopt' ],
+  'is'         => 'ro',
+  'lazy_build' => 1,
+);
+sub _build_npg_tracking_schema {
+  my ($self) = @_;
+  my$s = $self->has_tracking_run() ?
+         $self->run()->result_source()->schema() :
+         npg_tracking::Schema->connect();
+  return $s
+}
+
+=head2 mlwh_schema
+ 
+DBIx schema class for ml_warehouse access.
+
+=cut
+
+has 'mlwh_schema' => (
+  'isa'        => 'WTSI::DNAP::Warehouse::Schema',
+  'traits'     => [ 'NoGetopt' ],
+  'is'         => 'ro',
+  'required'   => 0,
+  'lazy_build' => 1,
+);
+sub _build_mlwh_schema {
+  return WTSI::DNAP::Warehouse::Schema->connect();
+}
+
+
+=head2 run
+
+An attribute, DBIx object for a row in the run table of the tracking database.
+
+=cut
+
+has 'run' => (
+  'isa'        => 'npg_tracking::Schema::Result::Run',
+  'traits'     => [ 'NoGetopt' ],
+  'is'         => 'ro',
+  'predicate'  => 'has_tracking_run',
+  'lazy_build' => 1,
+);
+sub _build_run {
+  my $self=shift;
+
+  if (!$self->id_run) {
+    croak 'Run ID is not available, cannot retrieve run database record';
+  }
+  my $run = $self->npg_tracking_schema->resultset(q(Run))->find($self->id_run);
+  if (!$run) {
+    croak 'The database record for run ' . $self->id_run  . ' does not exist';
+  }
+
+  return $run;
+}
+
+
+=head2 lims
+
+An attribute, an array of st::api::lims type objects.
+
+To generate a samplesheet for the whole run, provide an array of
+at::api::lims objects for all lanes of the run.
+
+This attribute should normally be provided by the caller via the
+constuctor. If the attribute is not provided, it is built automatically,
+using the ml_warehouse lims driver.
+
+=cut
+
+has 'lims' => (
+  'isa'        => 'ArrayRef[st::api::lims]',
+  'traits'     => [ 'NoGetopt' ],
+  'is'         => 'ro',
+  'lazy_build' => 1,
+);
+sub _build_lims {
+  my $self=shift;
+
+  my $run_lims = st::api::lims->new(
+    driver_type      => $LIMS_DRIVER_TYPE,
+    id_flowcell_lims => $self->batch_id,
+    mlwh_schema      => $self->mlwh_schema
+  );
+
+  return [$run_lims->children()];
+};
+
+__PACKAGE__->meta->make_immutable;
+
+1;
+
+__END__
+
+
+=head1 DEPENDENCIES
+
+=over
+
+=item Moose
+
+=item namespace::autoclean
+
+=item Readonly
+
+=item Carp
+
+=item MooseX::Getopt::Meta::Attribute::Trait::NoGetopt
+
+=item WTSI::DNAP::Warehouse::Schema
+
+=item npg_tracking::Schema
+
+=item  st::api::lims
+
+=item npg_tracking::util::config
+
+=item npg_tracking::glossary::run
+
+=back
+
+=head1 INCOMPATIBILITIES
+
+=head1 BUGS AND LIMITATIONS
+
+=head1 AUTHOR
+
+David K. Jackson E<lt>david.jackson@sanger.ac.ukE<gt>
+
+Marina Gourtovaia E<lt>mg8@sanger.ac.ukE<gt>
+
+=head1 LICENSE AND COPYRIGHT
+
+Copyright (C) 2019, 2020, 2023 Genome Research Ltd.
+
+This file is part of NPG.
+
+NPG is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+=cut
+

--- a/lib/npg/samplesheet/novaseq_xseries.pm
+++ b/lib/npg/samplesheet/novaseq_xseries.pm
@@ -8,17 +8,13 @@ use Carp;
 use Text::CSV;
 use List::MoreUtils qw(any none uniq);
 use List::Util qw(first max);
-use Pod::Usage;
 use DateTime;
 use Data::UUID;
 
-use st::api::lims;
-use npg_tracking::Schema;
-use npg_tracking::util::types;
-use WTSI::DNAP::Warehouse::Schema;
+use st::api::lims::samplesheet;
 
-with qw / MooseX::Getopt
-          npg_tracking::glossary::run /;
+extends 'npg::samplesheet::base';
+with    'MooseX::Getopt';
 
 our $VERSION = '0';
 
@@ -38,9 +34,8 @@ Readonly::Hash my %REFERENCE_MAPING => (
   'Homo_sapiens' => 'hg38-alt_masked.cnv.graph.hla.rna-8-1667497097-2'
 );
 
-# DRAGEN can process a limited number of distinct configurations.
-# For on-board analysis it's 4.
 Readonly::Scalar my $DRAGEN_MAX_NUMBER_OF_CONFIGS => 4;
+Readonly::Scalar my $END_OF_LINE => qq[\n];
 
 =head1 NAME
 
@@ -116,48 +111,89 @@ sub _build_dragen_software_version {
 };
 
 
-=head2 id_run
+has '+samplesheet_path' => (
+  'documentation' => 'A directory where the samplesheet will be created, ' .
+  'optional',
+);
 
-NPG run ID, an optional attribute. If supplied, the record for this run
-should exists in the run tracking database.
+
+=head2 file_name
+
+CSV file name to write the samplesheet data to.
 
 =cut
 
+has 'file_name' => (
+  'isa'        => 'Str',
+  'is'         => 'ro',
+  'lazy_build' => 1,
+  'required'   => 0,
+  'documentation' => 'CSV file name to write the samplesheet data to, ' .
+                     'optional',
+);
+sub _build_file_name {
+  my $self = shift;
+
+  my $file_name;
+  if ($self->has_id_run) {
+    $file_name = join q[_],
+      $self->run_name,
+      q[ssbatch] . $self->batch_id;
+  } else {
+    $file_name = $self->run_name;
+  }
+
+  my $date =  DateTime->now()->strftime('%y%m%d'); # 230602 for 2 June 2023
+  $file_name = sprintf '%s_%s.csv', $date, $file_name;
+
+  return $file_name;
+}
+
+
+=head2 output
+
+A full path of the samplesheet file. If not supplied, is built using the
+values of C<samplesheet_path> and C<file_name> attributes.
+
+If the C<samplesheet_path> attribute is set to an empty string, the current
+working directory is assumed.
+
+Do not remove this attribute or change its name in order to be compliant with
+the samplesheet daemon C<npg::samplesheet::auto>.
+
+=cut
+
+has 'output' => (
+  'isa'        => 'Str',
+  'is'         => 'ro',
+  'lazy_build' => 1,
+  'isa'        => 'Str',
+  'documentation' => 'A path of the samplesheet file, optional',
+);
+sub _build_output {
+  my $self = shift;
+
+  my $dir = $self->samplesheet_path();
+  my $path = $self->file_name;
+  if ($dir) {
+    $dir =~ s{/\Z}{}xms; # Trim trailing slash if present.
+    $path = join q[/], $dir, $path;
+  }
+
+  return $path;
+}
+
+
 has '+id_run' => (
-  'required'  => 0,
   'documentation' => 'NPG run ID, optional; if supplied, the record for this '.
                      'run should exists in the run tracking database',
 );
 
 
-=head2 batch_id
-
-LIMS batch ID, an optional attribute. If not set, the C<id_run> attribute
-should be set.
-
-=cut
-
-has 'batch_id' => (
-  'isa' => 'Str|Int',
-  'is'  => 'ro',
-  'lazy_build' => 1,
-  'required'   => 0,
+has '+batch_id' => (
   'documentation' => 'LIMS batch identifier, optional. If not set, will be ' .
                      'retrieved from the tracking database record for the run',
 );
-sub _build_batch_id {
-  my $self = shift;
-  if (!$self->has_id_run) {
-    croak 'Run ID is not supplied, cannot get LIMS batch ID';
-  }
-  my $batch_id = $self->run()->batch_id();
-  if (!defined $batch_id) {
-    croak 'Batch ID is not set in the database record for run ' . $self->id_run;
-  }
-
-  return $batch_id;
-}
-
 
 =head2 index_read_length
 
@@ -175,7 +211,7 @@ has 'index_read_length' => (
   'lazy_build' => 1,
   'required'   => 0,
   'documentation' => 'An array containing the length of the first and the ' .
-                     'second (if applicable) indexing read..',
+                     'second (if applicable) indexing read.',
 );
 sub _build_index_read_length {
   my $self = shift;
@@ -273,96 +309,6 @@ has 'dragen_max_number_of_configs' => (
 );
 
 
-=head2 npg_tracking_schema
-
-DBIx Schema object for the tracking database.
-
-=cut
-
-has 'npg_tracking_schema' => (
-  'isa'        => 'npg_tracking::Schema',
-  'is'         => 'ro',
-  'lazy_build' => 1,
-  'traits'     => [ 'NoGetopt' ],
-);
-sub _build_npg_tracking_schema {
-  return npg_tracking::Schema->connect();
-}
-
-
-=head2 mlwh_schema
-
-DBIx Schema object for the mlwh database.
-
-=cut
-
-has 'mlwh_schema' => (
-  'isa'        => 'WTSI::DNAP::Warehouse::Schema',
-  'is'         => 'ro',
-  'lazy_build' => 1,
-  'traits'     => [ 'NoGetopt' ],
-);
-sub _build_mlwh_schema {
-  return WTSI::DNAP::Warehouse::Schema->connect();
-}
-
-
-=head2 run
-
-DBIx object for a row in the run table of the tracking database.
-
-=cut
-
-has 'run' => (
-  'isa'        => 'npg_tracking::Schema::Result::Run',
-  'is'         => 'ro',
-  'predicate'  => 'has_tracking_run',
-  'lazy_build' => 1,
-  'traits'     => [ 'NoGetopt' ],
-);
-sub _build_run {
-  my $self=shift;
-
-  if (!$self->has_id_run) {
-    croak 'Run ID is not supplied, cannot retrieve run database record';
-  }
-  my $run = $self->npg_tracking_schema->resultset(q(Run))->find($self->id_run);
-  if (!$run) {
-    croak 'The database record for run ' . $self->id_run  . ' does not exist';
-  }
-  if ($run->instrument_format()->model() !~ /NovaSeqX/smx) {
-    croak 'Instrument model is not NovaSeq X Series';
-  }
-
-  return $run;
-}
-
-
-=head2 lims
-
-An attribute, an array of C<st::api::lims> type objects.
-
-If the attribute is not provided, it is built automatically.
-c<ml_warehouse st::api::lims> driver is used to access LIMS data.
-
-=cut
-
-has 'lims' => (
-  'isa'        => 'ArrayRef[st::api::lims]',
-  'is'         => 'ro',
-  'lazy_build' => 1,
-  'traits'     => [ 'NoGetopt' ],
-);
-sub _build_lims {
-  my $self=shift;
-  return [st::api::lims->new(
-            id_flowcell_lims => $self->batch_id,
-            driver_type => q[ml_warehouse],
-            mlwh_schema => $self->mlwh_schema
-          )->children()];
-}
-
-
 =head2 run_name
 
 =cut
@@ -378,7 +324,10 @@ sub _build_run_name {
   my $self = shift;
 
   my $run_name;
-  if ($self->has_id_run()) {
+  if ($self->id_run()) {
+    if ($self->run->instrument_format()->model() !~ /NovaSeqX/smx) {
+      croak 'Instrument model is not NovaSeq X Series';
+    }
     # Embed instrument's Sanger network name and slot
     $run_name = sprintf '%s_%s_%s', $self->id_run,
       $self->run->instrument->name, $self->get_instrument_side;
@@ -391,36 +340,6 @@ sub _build_run_name {
   }
 
   return $run_name;
-}
-
-
-=head2 file_name
-
-=cut
-
-has 'file_name' => (
-  'isa'        => 'Str',
-  'is'         => 'ro',
-  'lazy_build' => 1,
-  'required'   => 0,
-  'documentation' => 'CSV file name or path to write samplesheet data to',
-);
-sub _build_file_name {
-  my $self = shift;
-
-  my $file_name;
-  if ($self->has_id_run) {
-    $file_name = join q[_],
-      $self->run_name,
-      q[ssbatch] . $self->batch_id;
-  } else {
-    $file_name = $self->run_name;
-  }
-
-  my $date =  DateTime->now()->strftime('%y%m%d'); # 230602 for 2 June 2023
-  $file_name = sprintf '%s_%s.csv', $date, $file_name;
-
-  return $file_name;
 }
 
 
@@ -471,6 +390,9 @@ sub _build__products {
 
 Generates a samplesheet and saves it to a file.
 
+Do not remove this method or change its name in order to stay compliant
+with samplesheet daemon C<npg::samplesheet::auto>.
+
 =cut
 
 sub process {
@@ -508,30 +430,7 @@ sub process {
     carp 'Too many BCLConvert configurations, cannot run any DRAGEN analysis';
   }
 
-
-  my $csv = Text::CSV->new({
-    eol      => qq[\n],
-    sep_char => q[,],
-  });
-
-  my $max_num_columns = max map { scalar @{$_} } @{$self->_all_lines};
-
-  my $file_name = $self->file_name;
-  ## no critic (InputOutput::RequireBriefOpen)
-  open my $fh, q[>], $file_name
-    or croak "Failed to open $file_name for writing";
-
-  for my $line (@{$self->_all_lines}) {
-    my @columns = @{$line};
-    # Pad the row.
-    while (scalar @columns < $max_num_columns) {
-      push @columns, q[];
-    }
-    $csv->print($fh, \@columns);
-  }
-
-  close $fh or carp "Problems closing $file_name";
-  ## use critic
+  $self->_generate_output();
 
   return;
 }
@@ -898,6 +797,37 @@ sub _can_add_sample {
   return 1;
 }
 
+
+sub _generate_output {
+  my $self = shift;
+
+  my $csv = Text::CSV->new({
+    eol => $END_OF_LINE,
+    sep_char => $st::api::lims::samplesheet::SAMPLESHEET_RECORD_SEPARATOR
+  });
+
+  my $max_num_columns = max map { scalar @{$_} } @{$self->_all_lines};
+
+  my $file_path = $self->output;
+  ## no critic (InputOutput::RequireBriefOpen)
+  open my $fh, q[>], $file_path
+    or croak "Failed to open $file_path for writing";
+
+  for my $line (@{$self->_all_lines}) {
+    my @columns = @{$line};
+    # Pad the row.
+    while (scalar @columns < $max_num_columns) {
+      push @columns, q[];
+    }
+    $csv->print($fh, \@columns);
+  }
+
+  close $fh or carp "Problems closing $file_path";
+  ## use critic
+
+  return;
+}
+
 __PACKAGE__->meta->make_immutable;
 
 1;
@@ -930,19 +860,9 @@ __END__
 
 =item List::Util
 
-=item Pod::Usage
-
 =item DateTime
 
 =item Data::UUID
-
-=item st::api::lims
-
-=item npg_tracking::Schema
-
-=item npg_tracking::util::types
-
-=item WTSI::DNAP::Warehouse::Schema
 
 =back
 
@@ -956,7 +876,7 @@ Marina Gourtovaia E<lt>mg8@sanger.ac.ukE<gt>
 
 =head1 LICENSE AND COPYRIGHT
 
-Copyright (C) 2023 Genome Research Ltd
+Copyright (C) 2023 Genome Research Ltd.
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/lib/npg/samplesheet/novaseq_xseries.pm
+++ b/lib/npg/samplesheet/novaseq_xseries.pm
@@ -143,7 +143,7 @@ sub _build_file_name {
     $file_name = $self->run_name;
   }
 
-  my $date =  DateTime->now()->strftime('%y%m%d'); # 230602 for 2 June 2023
+  my $date = DateTime->now()->strftime('%y%m%d'); # 230602 for 2 June 2023
   $file_name = sprintf '%s_%s.csv', $date, $file_name;
 
   return $file_name;
@@ -176,7 +176,7 @@ sub _build_output {
   my $dir = $self->samplesheet_path();
   my $path = $self->file_name;
   if ($dir) {
-    $dir =~ s{/\Z}{}xms; # Trim trailing slash if present.
+    $dir =~ s{[/]+\Z}{}xms; # Trim trailing slash if present.
     $path = join q[/], $dir, $path;
   }
 
@@ -326,7 +326,8 @@ sub _build_run_name {
   my $run_name;
   if ($self->id_run()) {
     if ($self->run->instrument_format()->model() !~ /NovaSeqX/smx) {
-      croak 'Instrument model is not NovaSeq X Series';
+      croak 'Instrument is not registered as NovaSeq X Series ' .
+            'in the tracking database';
     }
     # Embed instrument's Sanger network name and slot
     $run_name = sprintf '%s_%s_%s', $self->id_run,

--- a/t/.npg/npg_tracking
+++ b/t/.npg/npg_tracking
@@ -3,7 +3,6 @@ my $VAR1 = {
   'staging_areas' => {
     'indexes' => [18 .. 32, 34 .. 47, 49 .. 55],
     'prefix' => '/nfs/sf',
-    'samplesheets' => '/nfs/sf49/ILorHSorMS_sf49/samplesheets/'
   },
   'staging_areas2webservers' => {
     'gs01'    => {'npg_tracking' => 'http://gso1.san.ac.uk:678',

--- a/t/47-npg_samplesheet_novaseq_xseries.t
+++ b/t/47-npg_samplesheet_novaseq_xseries.t
@@ -26,7 +26,7 @@ my $schema_wh = $class->new_object({})->create_test_db(
 my $date = DateTime->now()->strftime('%y%m%d');
 
 subtest 'create the generator object, test simple attributes' => sub {
-  plan tests => 16;
+  plan tests => 17;
 
   my $g = npg::samplesheet::novaseq_xseries->new(
     npg_tracking_schema => $schema_tracking,
@@ -116,6 +116,14 @@ subtest 'create the generator object, test simple attributes' => sub {
     npg_tracking_schema => $schema_tracking,
     mlwh_schema         => $schema_wh,
     id_run              => 47446,
+    samplesheet_path    => "$dir/one///"
+  );
+  is ($g->output, "$dir/one/$file_name", 'correct output path is generated');
+  
+  $g = npg::samplesheet::novaseq_xseries->new(
+    npg_tracking_schema => $schema_tracking,
+    mlwh_schema         => $schema_wh,
+    id_run              => 47446,
     samplesheet_path    => q[]
   );
   is ($g->output, $file_name, 'correct output path is generated');
@@ -127,7 +135,7 @@ subtest 'create the generator object, test simple attributes' => sub {
     id_run              => 47446,
   );
   throws_ok { $g->file_name }
-    qr/Instrument model is not NovaSeq X Series/,
+    qr/Instrument is not registered as NovaSeq X Series/,
     'error when the run is registered on the wrong instrument model';
 };
 

--- a/t/47-samplesheet.t
+++ b/t/47-samplesheet.t
@@ -9,8 +9,6 @@ use File::Path qw/make_path/;
 use Moose::Meta::Class;
 
 use t::dbic_util;
-local $ENV{'dev'} = q(wibble);
-local $ENV{'HOME'} = q(t/);
 
 use_ok('npg::samplesheet');
 use_ok('st::api::lims');
@@ -21,8 +19,6 @@ my $class = Moose::Meta::Class->create_anon_class(roles=>[qw/npg_testing::db/]);
 my $mlwh_schema = $class->new_object({})->create_test_db(
   q[WTSI::DNAP::Warehouse::Schema], q[t/data/fixtures_lims_wh_samplesheet]
 );
-
-local $ENV{NPG_WEBSERVICE_CACHE_DIR} = q(t/data/samplesheet);
 
 my $dir = tempdir( CLEANUP => 1 );
 
@@ -51,22 +47,19 @@ subtest 'object creation' => sub {
   lives_ok { $ss = npg::samplesheet->new(mlwh_schema => $mlwh_schema,
     repository=>$dir, npg_tracking_schema=>$schema, id_run=>7007); }
     'samplesheet object - no output provided';
-  cmp_ok($ss->output, 'eq',
-    '/nfs/sf49/ILorHSorMS_sf49/samplesheets/wibble/MS0001309-300.csv',
+  cmp_ok($ss->output, 'eq', 'samplesheets/MS0001309-300.csv',
     'default output location (with zeroes trimmed appropriately)');
 
   lives_ok { $ss = npg::samplesheet->new(mlwh_schema => $mlwh_schema,
     repository=>$dir, npg_tracking_schema=>$schema, id_run=>6946); }
     'samplesheet object - no output provided';
-  cmp_ok($ss->output, 'eq',
-    '/nfs/sf49/ILorHSorMS_sf49/samplesheets/wibble/000000000-A0616.csv',
+  cmp_ok($ss->output, 'eq', 'samplesheets/000000000-A0616.csv',
     'default output location');
 
   lives_ok { $ss = npg::samplesheet->new(mlwh_schema => $mlwh_schema, repository=>$dir, npg_tracking_schema=>$schema, id_run=>7007); } 'samplesheet object - no output provided';
   my $orig_flowcell_id = $ss->run->flowcell_id;
   $ss->run->flowcell_id(q(MS2000132-500V2));
-  cmp_ok($ss->output, 'eq',
-    '/nfs/sf49/ILorHSorMS_sf49/samplesheets/wibble/MS2000132-500V2.csv',
+  cmp_ok($ss->output, 'eq', 'samplesheets/MS2000132-500V2.csv',
     'default output location copes with V2 MiSeq cartirdges/reagent kits');
 };
 


### PR DESCRIPTION
Built on top of https://github.com/wtsi-npg/npg_tracking/pull/794

Created a parent class for two existing samplesheet
generators. Moved common methods to this class.

Through this inheritance the NovaSeqX samplesheet
generator gets a standard method for setting a path for the
samplesheet.

An option to set the path from a value in the configuration file
is dropped - it was not used for years.

