### PR TITLE
Correctly propagate driver details for mlwh driver

### DIFF
--- a/lib/st/api/lims.pm
+++ b/lib/st/api/lims.pm
@@ -897,9 +897,8 @@ sub aggregate_xlanes {
     return;
   }; # End of test function
 
-  my %init = %{$self->_driver_arguments()};
-  $init{'driver_type'} = $self->driver_type;
-  delete $init{'id_run'};
+  my $init = $self->copy_init_args();
+  delete $init->{'id_run'};
 
   my $lims4compisitions = {};
   my @test_attrs = qw/sample_id library_id/;
@@ -908,7 +907,7 @@ sub aggregate_xlanes {
 
   if (!@pools) {
     $can_merge->(\@lanes, @test_attrs); # Test consistency
-    push @aggregated, __PACKAGE__->new(%init, rpt_list => $lanes_rpt_list);
+    push @aggregated, __PACKAGE__->new(%{$init}, rpt_list => $lanes_rpt_list);
   } else {
     my @sizes = uniq (map { $_->num_children } @lanes);
     if (@sizes != 1) { # Test consistency
@@ -925,11 +924,11 @@ sub aggregate_xlanes {
     my $ea = each_arrayref map { [$_->children()] } @lanes;
     while ( my @plexes = $ea->() ) {
       $can_merge->(\@plexes, @test_attrs, 'tag_index');  # Test consistency
-      push @aggregated, __PACKAGE__->new(%init,
+      push @aggregated, __PACKAGE__->new(%{$init},
         rpt_list => npg_tracking::glossary::rpt->deflate_rpts(\@plexes));
     }
     # Add object for tag zero
-    push @aggregated, __PACKAGE__->new(%init,
+    push @aggregated, __PACKAGE__->new(%{$init},
       rpt_list => npg_tracking::glossary::rpt->tag_zero_rpt_list($lanes_rpt_list));
   }
 

--- a/lib/st/api/lims.pm
+++ b/lib/st/api/lims.pm
@@ -1092,7 +1092,7 @@ sub _check_value_is_unique {
 
 =head2 create_tag_zero_object
  
-Using id_run and position values of this object, creates and returns
+Using run ID and position values of this object, creates and returns
 st::api::lims object for tag zero. The new object has the same driver
 settings as the original object.
 
@@ -1109,10 +1109,9 @@ sub create_tag_zero_object {
   if (!defined $self->position) {
     croak 'Position should be defined';
   }
-  my %init = %{$self->_driver_arguments()};
-  $init{'driver_type'} = $self->driver_type;
-  $init{'tag_index'}   = 0;
-  return __PACKAGE__->new(%init);
+  my $init = $self->copy_init_args();
+  $init->{'tag_index'}   = 0;
+  return __PACKAGE__->new(%{$init});
 }
 
 =head2 create_lane_object

--- a/lib/st/api/lims.pm
+++ b/lib/st/api/lims.pm
@@ -167,7 +167,6 @@ sub BUILD {
   my %dargs=();
   my %pargs=();
   my %primary_arg_type = map {$_ => 1} @{$METHODS_PER_CATEGORY{'primary'}};
-
   my $driver_class=$self->_driver_package_name;
 
   foreach my$k (grep {defined && $_ !~ /^_/smx} map{ $_->has_init_arg ? $_->init_arg : $_->name}
@@ -196,6 +195,28 @@ sub BUILD {
   croak 'Unknown attributes: '.join q(, ), keys %args if keys %args;
   $self->_set__primary_arguments(\%pargs);
   return;
+}
+
+=head2 copy_init_args
+
+Returns a hash reference that can be used to initialise st::api::lims
+objects similar to this object. The driver details, if present in this
+object, are returned under the 'driver_type' key and, if relevant,
+'mlwh_schema' key. 
+
+=cut
+sub copy_init_args {
+  my $self = shift;
+
+  my %init = %{$self->_driver_arguments()};
+  if ($self->driver_type()) {
+    $init{'driver_type'} = $self->driver_type();
+    if (!$init{'mlwh_schema'} && $init{'driver_type'} =~ /warehouse/smx) {
+      $init{'mlwh_schema'} =  $self->driver()->mlwh_schema;
+    }
+  }
+
+  return \%init;
 }
 
 # Mapping of LIMS object types to attributes for which methods are to
@@ -724,7 +745,7 @@ sub _build__cached_children {
   my $self = shift;
 
   my @children = ();
-  my @basic_attrs = qw/id_run position tag_index/;
+  my @basic_attrs = @{$METHODS_PER_CATEGORY{'primary'}};
   my $driver_type = $self->driver_type;
 
   if ($self->driver) {
@@ -760,7 +781,9 @@ sub _build__cached_children {
         my %init = %{$self->_driver_arguments()};
         $init{'driver_type'} = $driver_type;
         foreach my $attr (@basic_attrs) {
-          $init{$attr} = $component->$attr;
+          if ($component->can($attr)) {
+            $init{$attr} = $component->$attr;
+          }
         }
         push @children, __PACKAGE__->new(\%init);
       }
@@ -953,7 +976,7 @@ This method can be used both as instance and as a class method.
 
 =cut
 
-sub aggregate_libraries() {
+sub aggregate_libraries {
   my ($self, $lane_lims_array) = @_;
 
   # This restriction might be lifted in future.
@@ -975,9 +998,9 @@ sub aggregate_libraries() {
   # to create objects for merged entities.
   # Do not use $self for copying the driver arguments in order to retain
   # ability to use this method as a class method.
-  my %init = %{$lane_lims_array->[0]->_driver_arguments()};
-  delete $init{position};
-  delete $init{id_run};
+  my $init = $lane_lims_array->[0]->copy_init_args();
+  delete $init->{position};
+  delete $init->{id_run};
 
   my $merges = {};
   my $lane_set_delim = q[,];
@@ -1005,7 +1028,7 @@ sub aggregate_libraries() {
         ->new(rpt_list => $rpt_list)->create_composition()
         ->freeze2rpt();
       $merges->{$lane_set}->{$tag_index} = __PACKAGE__->new(
-        %init, rpt_list => $rpt_list
+        %{$init}, rpt_list => $rpt_list
       );
     }
   }
@@ -1045,7 +1068,7 @@ sub aggregate_libraries() {
   return $all_lims_objects;
 }
 
-sub _check_merge_correctness{
+sub _check_merge_correctness {
   my $lib_lims = shift;
   my @lanes = uniq  map {$_->position} @{$lib_lims};
   if (@lanes != @{$lib_lims}) {

--- a/lib/st/api/lims.pm
+++ b/lib/st/api/lims.pm
@@ -1129,13 +1129,12 @@ attributes. The new object has the same driver settings as the original object.
 sub create_lane_object {
   my ($self, $id_run, $position) = @_;
   ($id_run and $position) or croak 'id_run and position are expected as arguments';
-  my %init = %{$self->_driver_arguments()};
-  $init{'driver_type'} = $self->driver_type;
-  delete $init{'tag_index'};
-  delete $init{'rpt_list'};
-  $init{'id_run'}   = $id_run;
-  $init{'position'} = $position;
-  return __PACKAGE__->new(%init);
+  my $init = $self->copy_init_args();
+  delete $init->{'tag_index'};
+  delete $init->{'rpt_list'};
+  $init->{'id_run'}   = $id_run;
+  $init->{'position'} = $position;
+  return __PACKAGE__->new(%{$init});
 }
 
 =head2 cached_samplesheet_var_name

--- a/t/40-st-lims-mlwarehouse.t
+++ b/t/40-st-lims-mlwarehouse.t
@@ -1,6 +1,6 @@
 use strict;
 use warnings;
-use Test::More tests => 6;
+use Test::More tests => 7;
 use Test::Exception;
 
 use_ok('st::api::lims');
@@ -162,6 +162,31 @@ subtest 'sample controls' => sub {
         is($l->sample_control_type, undef, 'sample control type is undefined');
       }
     }
+};
+
+subtest 'using rpt_list argument' => sub { 
+    plan tests => 14;
+    
+    my $lims = st::api::lims->new(
+        rpt_list         => '47995:1:3;47995:2:3',
+        id_flowcell_lims => 98292,
+        driver_type      => 'ml_warehouse',
+        mlwh_schema      => $schema_wh,
+    );
+    my $sample_name = '6751STDY13219555';
+    is ($lims->sample_name, $sample_name, 'correct sample name');
+    my @children = $lims->children();
+    is (@children, 2, 'two child objects');
+    for my $i ((0, 1)) {
+        my $child = $children[$i];
+        is ($child->driver_type, 'ml_warehouse', 'child driver type is correct');
+        is ($child->driver->mlwh_schema, $schema_wh,
+            q[child's driver is using the original db connection]);
+        is ($child->id_run, 47995, 'child run is is correct');
+        is ($child->tag_index, 3, 'child tag index is is correct');
+        is ($child->position, $i+1, 'child position is is correct');
+        is ($child->sample_name, $sample_name, 'child sample name is correct');  
+    }  
 };
 
 1;

--- a/t/40-st-lims.t
+++ b/t/40-st-lims.t
@@ -1,6 +1,6 @@
 use strict;
 use warnings;
-use Test::More tests => 16;
+use Test::More tests => 15;
 use Test::Exception;
 use Test::Warn;
 use Moose::Meta::Class;
@@ -340,26 +340,6 @@ subtest 'Samplesheet driver for arbitrary compositions' => sub {
   is ($ss->id_run, 28780, 'correct run id');
   is ($ss->position, 2, 'correct position');
   is ($ss->tag_index, 4, 'correct tag_index');
-};
-
-subtest 'Creating tag zero object' => sub {
-  plan tests => 4;
-
-  local $ENV{NPG_CACHED_SAMPLESHEET_FILE} = 't/data/test40_lims/samplesheet_novaseq4lanes.csv';
-
-  my $l = st::api::lims->new(id_run => 25846);
-  throws_ok { $l->create_tag_zero_object() } qr/Position should be defined/,
-    'method cannot be called on run-level object';
-  $l = st::api::lims->new(rpt_list => '25846:2:1');
-  throws_ok { $l->create_tag_zero_object() } qr/Position should be defined/,
-    'method cannot be called on an object for a composition';
-
-  my $description = 'st::api::lims object, driver - samplesheet, id_run 25846, ' .
-    'path t/data/test40_lims/samplesheet_novaseq4lanes.csv, position 3, tag_index 0';
-  $l = st::api::lims->new(id_run => 25846, position => 3);
-  is ($l->create_tag_zero_object()->to_string(), $description, 'created from lane-level object');
-  $l = st::api::lims->new(id_run => 25846, position => 3, tag_index => 5);
-  is ($l->create_tag_zero_object()->to_string(), $description, 'created from plex-level object');
 };
 
 subtest 'Dual index' => sub {


### PR DESCRIPTION
This pr is resolves a bug that went untetected for a long time. The bug came to light while refactoring the samplesheet generation for NovaSeqX. The samplesheet daemon uses the `ml_warehouse` driver. A silent switch to the default samplesheet driver was happenning, which resulted in an error since the samplesheet to read from cannot be found. While extending the tests in this pr, another variation of this bug was observed - a switch from a connection to the test database to a connection to a live database.