### PR TITLE
Stop parsing run info from run folder name

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -91,12 +91,9 @@ my $builder = $class->new(
 
           'build_requires' => {
                 'ExtUtils::CBuilder'              => 0,
-                'Archive::Tar'                    => 0,
                 'DateTime::Duration'              => 0,
                 'DateTime::Format::SQLite'        => 0,
                 'HTTP::Headers'                   => 0,
-                'IO::File'                        => 0,
-                'IPC::Open2'                      => 0,
                 'List::Util'                      => 0,
                 'Test::Compile'                   => 0,
                 'Test::Distribution'              => 0,

--- a/Changes
+++ b/Changes
@@ -1,6 +1,17 @@
 LIST OF CHANGES
 
 
+ - npg_tracking::illumina::run::short_info
+     - Stopped parsing out run details from the run folder name. Deleted
+       attributes, which were populated this way: 'name', 'instrument_string',
+       'slot', 'flowcell_id'.
+     - Deleted 'short_reference' method.
+ - npg_tracking::illumina::run::folder
+     - Removed dependency on 'short_reference' method, which used to be
+       provided by npg_tracking::illumina::run::short_info.
+     - Introduce a check to ensure that the run folder name on staging and
+       in the database, when both are available, are the same.
+
 release 100.0.1
  - For aggregation of lims objects by library in st::api::lims, do not
    consider the same library with different tag index in the same lane

--- a/MANIFEST
+++ b/MANIFEST
@@ -418,7 +418,6 @@ t/80-npg_tracking-report-events.t
 t/80-npg_tracking-report-event2followers.t
 t/80-npg_tracking-report-event2subscribers.t
 t/data/schema.txt
-t/data/090414_IL24_2726.tar.bz2
 t/data/dbic_fixtures/000-Designation.yml
 t/data/dbic_fixtures/000-EntityType.yml
 t/data/dbic_fixtures/000-InstrumentModDict.yml

--- a/lib/npg_tracking/illumina/runfolder.pm
+++ b/lib/npg_tracking/illumina/runfolder.pm
@@ -6,6 +6,7 @@ package npg_tracking::illumina::runfolder;
 #
 
 use Moose;
+use MooseX::StrictConstructor;
 use namespace::autoclean;
 use Carp;
 use File::Spec;
@@ -24,7 +25,6 @@ npg_tracking::illumina::runfolder
 
   my $oRunfolder = npg_tracking::illumina::runfolder->new(
     runfolder_path => '/staging/IL29/incoming/090721_IL29_3379/');
-  my $name = $oRunfolder->name; # 090721_IL29_3379
   my $id = $oRunfolder->id_run; # 3379
 
 =head1 DESCRIPTION
@@ -42,7 +42,7 @@ with 'npg_tracking::illumina::run::long_info';
 
 sub _build_run_folder {
   my $self = shift;
-  ($self->subpath or $self->has_id_run or $self->has_name)
+  ($self->subpath or $self->has_id_run)
       or croak 'Need a path or id_run to work out a run_folder';
   return first {$_ ne q()} reverse File::Spec->splitdir($self->runfolder_path);
 }
@@ -60,6 +60,8 @@ __PACKAGE__->meta->make_immutable;
 =over
 
 =item Moose
+
+=item MooseX::StrictConstructor
 
 =item Carp
 
@@ -81,7 +83,7 @@ David K. Jackson, E<lt>david.jackson@sanger.ac.ukE<gt>
 
 =head1 LICENSE AND COPYRIGHT
 
-Copyright (C) 2018 GRL
+Copyright (C) 2018,2019,2024 Genome Research Ltd.
 
 This file is part of NPG.
 

--- a/t/60-illumina-run-long_info.t
+++ b/t/60-illumina-run-long_info.t
@@ -1,30 +1,14 @@
 use strict;
 use warnings;
-use Test::More tests => 68;
+use Test::More tests => 31;
 use Test::Exception;
 use Test::Deep;
 use File::Temp qw(tempdir);
 use Moose::Meta::Class;
-use Cwd;
-use Carp;
 use File::Copy;
 use File::Slurp qw(edit_file_lines);
 
-BEGIN {
-  local $ENV{'HOME'} = getcwd() . '/t';
-  use_ok(q{npg_tracking::illumina::run::long_info});
-
-  # package creation within BEGIN block to ensure after HOME is reset
-  package test::long_info;
-  use Moose;
-  with qw{npg_tracking::illumina::run::short_info
-          npg_tracking::illumina::run::folder};
-  with qw{npg_tracking::illumina::run::long_info};
-  no Moose;
-  1;
-}
-
-package main;
+use_ok(q{npg_tracking::illumina::run::long_info});
 
 my $basedir = tempdir( CLEANUP => 1 );
 
@@ -324,196 +308,67 @@ subtest 'getting experiment name from runParameters' => sub {
   }
 };
 
-local $ENV{'TEST_DIR'} = $basedir; #so when npg_tracking::illumina::run::folder globs the test directory
-local $ENV{'dev'} = 'none';
-
-my $id_run = q{1234};
-my $name = q{IL2_1234};
-my $run_folder = q{123456_IL2_1234};
-my $runfolder_path = qq{$basedir/nfs/sf44/IL2/analysis/123456_IL2_1234};
-my $data_subpath = $runfolder_path . q{/Data};
-my $intensities_subpath = $data_subpath . q{/Intensities};
-my $basecalls_subpath = $intensities_subpath . q{/BaseCalls};
-my $bustard_subpath = $intensities_subpath . q{/Bustard-2009-10-01};
-my $gerald_subpath = $bustard_subpath . q{/GERALD-2009-10-01};
-my $archive_subpath = $gerald_subpath . q{/archive};
-my $qc_subpath = $archive_subpath . q{/qc};
-my $config_path = $runfolder_path . q{/Config};
-
-sub delete_staging {
-  `rm -rf $basedir/nfs`;
-  return 1;
-}
-
-sub create_staging {
-  my ($id_run, $lanes, $cycles) = @_;
-  delete_staging();
-  `mkdir -p $qc_subpath`;
-  `mkdir $basecalls_subpath`;
-
-  $lanes = $lanes || 8;
-  if ( $cycles ) {
-    $cycles = qq[<Read Number="1" NumCycles="$cycles" IsIndexedRead="Y  " />];
-  } else {
-    $cycles = <<"ENDXML";
-      <Read Number="1" NumCycles="76" IsIndexedRead="N" />
-      <Read Number="2" NumCycles="8" IsIndexedRead="Y" />
-      <Read Number="3" NumCycles="76" IsIndexedRead="N" />
-ENDXML
-  }
-
-  my $runparamsfile = qq[$runfolder_path/runParameters.xml];
-  open(my $fh, '>', $runparamsfile) or die "Could not open file '$runparamsfile' $!";
-  print $fh <<"ENDXML";
-<?xml version="1.0"?>
-<RunParameters xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-<Setup>
-  <ApplicationName>HiSeq Control Software</ApplicationName>
-  <ExperimentName>$id_run</ExperimentName>
-</Setup>
-</RunParameters>
-ENDXML
-  close $fh;
-
-  my $runinfofile = qq[$runfolder_path/RunInfo.xml];
-  open($fh, '>', $runinfofile) or die "Could not open file '$runinfofile' $!";
-  print $fh <<"ENDXML";
-<?xml version="1.0"?>
-<RunInfo xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Version="3">
-<Run>
-  <Reads>
-$cycles
-  </Reads>
-  <FlowcellLayout LaneCount="$lanes" SurfaceCount="2" SwathCount="1" TileCount="60">
-  </FlowcellLayout>
-</Run>
-</RunInfo>
-ENDXML
-  close $fh;
-  return 1;
-}
-
-sub create_latest_summary_link {
-  create_staging();
-  `ln -s $gerald_subpath $runfolder_path/Latest_Summary`;
-  return 1;
-}
-
-my $orig_dir = getcwd();
-
 {
+  my $rf = 't/data/long_info/nfs/sf20/ILorHSany_sf20/incoming/100914_HS3_05281_A_205MBABXX';
+  my $class = Moose::Meta::Class->create_anon_class(
+    methods => {"runfolder_path" => sub {$rf}},
+    roles   => [qw/npg_tracking::illumina::run::long_info/]);
   my $long_info;
-  lives_ok  { $long_info = test::long_info->new({id_run => 1234}); } q{created role_test object ok};
-
-  create_staging(1234, 8);
-
-  lives_ok  { $long_info = test::long_info->new({id_run => 1234}); } q{created role_test object ok};
-  is($long_info->is_paired_read(), 1, q{Read is paired});
-  lives_ok  { $long_info = test::long_info->new({id_run => 1234}); } q{created role_test object ok};
-  is($long_info->is_indexed(), 1, q{Read is indexed});
-
-  lives_ok  { $long_info = test::long_info->new({id_run => 1234}); } q{created role_test object ok};
-  is($long_info->lane_count(), 8, q{correct number of lanes});
-
-  lives_ok  { $long_info = test::long_info->new({id_run => 1234}); } q{created role_test object ok};
-  is($long_info->expected_cycle_count(), 160, q{correct number of expected cycles});
-  lives_ok  { $long_info = test::long_info->new({id_run => 1234}); } q{created role_test object ok};
-  is($long_info->cycle_count(), 160, q{cycle count returns the same as expected_cycle_count});
-
-  lives_ok  { $long_info = test::long_info->new({id_run => 1234}); } q{created role_test object ok};
-  is($long_info->tilelayout_columns(), 2, q{correct number of tilelayout_columns});
-  lives_ok  { $long_info = test::long_info->new({id_run => 1234}); } q{created role_test object ok};
-  is($long_info->tilelayout_rows(), 60, q{correct number of tilelayout_rows});
-  lives_ok  { $long_info = test::long_info->new({id_run => 1234}); } q{created role_test object ok};
-  is($long_info->tile_count(), 120, q{correct number of tiles});
-}
-
-chdir $orig_dir; #need to leave directories before you can delete them....
-eval { delete_staging(); } or do { carp 'unable to delete staging area'; };
-
-#Now let's test a new HiSeq directory....
-$ENV{TEST_DIR} = 't/data/long_info';
-{
-  my $long_info;
-  lives_ok  { $long_info = test::long_info->new({id_run => 5281}); } q{created role_test (HiSeq run 5281, RunInfo.xml) object ok};
+  lives_ok  { $long_info = $class->new_object(id_run => 5281); }
+    q{created role_test (HiSeq run 5281, RunInfo.xml) object ok};
   cmp_ok($long_info->tile_count, '==', 32, 'correct tile count');
-  lives_ok  { $long_info = test::long_info->new({id_run => 5281}); } q{created role_test (HiSeq run 5281, RunInfo.xml) object ok};
   cmp_ok($long_info->lane_count, '==', 8, 'correct lane count');
-  lives_ok  { $long_info = test::long_info->new({id_run => 5281}); } q{created role_test (HiSeq run 5281, RunInfo.xml) object ok};
   cmp_ok($long_info->cycle_count, '==', 200, 'correct cycle count');
 
-  lives_ok  { $long_info = test::long_info->new({id_run => 5281}); } q{created role_test (HiSeq run 5281, RunInfo.xml) object ok};
-  my $test_lane_tile_clustercount = {};
-  foreach my $i (1..8) {
-    foreach my $y (1..8) {
-      foreach my $add ( 0,20,40,60 ) {
-        $test_lane_tile_clustercount->{$i}->{$y + $add} = undef;
-      }
-    }
-  }
-
-  $long_info=undef;
-  lives_ok  { $long_info = test::long_info->new({id_run => 19395}); } q{created role_test (HiSeq run 19395, RunInfo.xml) object ok};
+  $rf = 't/data/long_info/nfs/sf20/ILorHSany_sf20/incoming/160408_HS31_19395_B_H5MMFADXY';
+  $class = Moose::Meta::Class->create_anon_class(
+    methods => {"runfolder_path" => sub {$rf}},
+    roles   => [qw/npg_tracking::illumina::run::long_info/]);
+  lives_ok  { $long_info = $class->new_object(id_run => 19395); } q{created role_test (HiSeq run 19395, RunInfo.xml) object ok};
   cmp_ok($long_info->lane_tilecount->{1}, '==', 64, 'correct lane 1 tile count');
-  lives_ok  { $long_info = test::long_info->new({id_run => 19395}); } q{created role_test (HiSeq run 19395, RunInfo.xml) object ok};
   cmp_ok($long_info->lane_tilecount->{2}, '==', 63, 'correct lane 2 tile count');
-  note($long_info->runfolder_path);
 }
 
-#Now let's test a NovaSeq directory....
-$ENV{TEST_DIR} = 't/data/long_info';
 {
-  my $long_info;
-
-  lives_ok  { $long_info = test::long_info->new({id_run => 25723}); } q{created role_test object ok};
+  my $rf = 't/data/long_info/nfs/sf20/ILorHSany_sf20/incoming/180426_NV1_25723_A_H3W2VDSXX';
+  my $long_info = Moose::Meta::Class->create_anon_class(
+    methods => {"runfolder_path" => sub {$rf}},
+    roles   => [qw/npg_tracking::illumina::run::long_info/]
+  )->new_object(id_run => 25723);
   is($long_info->tilelayout_columns(), 12, q{correct number of tilelayout_columns});
-  lives_ok  { $long_info = test::long_info->new({id_run => 25723}); } q{created role_test object ok};
   is($long_info->tilelayout_rows(), 78, q{correct number of tilelayout_rows});
-  lives_ok  { $long_info = test::long_info->new({id_run => 25723}); } q{created role_test object ok};
   is($long_info->tile_count(), 936, q{correct number of tiles});
-
-  $long_info=undef;
-  lives_ok  { $long_info = test::long_info->new({id_run => 25723}); } q{created role_test (HiSeq run 19395, RunInfo.xml) object ok};
   cmp_ok($long_info->lane_tilecount->{1}, '==', 936, 'correct lane 1 tile count');
-  note($long_info->runfolder_path);
 }
 
 {
-  my $long_info;
   my $rfpath = q(t/data/long_info/nfs/sf20/ILorHSany_sf20/incoming/120110_M00119_0068_AMS0002022-00300);
-  lives_ok { $long_info = test::long_info->new({runfolder_path=>$rfpath}); } q{create test role for dual index paired};
+  my $long_info = Moose::Meta::Class->create_anon_class(
+    methods => {"runfolder_path" => sub {$rfpath}},
+    roles   => [qw/npg_tracking::illumina::run::long_info/])->new_object();
   cmp_ok( $long_info->expected_cycle_count, '==', 318, 'expected_cycle_count');
-  lives_ok { $long_info = test::long_info->new({runfolder_path=>$rfpath}); } q{create test role for dual index paired};
   lives_and { cmp_deeply( [$long_info->read_cycle_counts], [151,8,8,151], 'read_cycle_counts match');} 'read_cycle_counts live and match';
-  lives_ok { $long_info = test::long_info->new({runfolder_path=>$rfpath}); } q{create test role for dual index paired};
   lives_and { cmp_deeply( [$long_info->read1_cycle_range], [1,151], 'read1_cycle_range matches');} 'read1_cycle_range lives and matches';
-  lives_ok { $long_info = test::long_info->new({runfolder_path=>$rfpath}); } q{create test role for dual index paired};
   lives_and { cmp_deeply( [$long_info->indexing_cycle_range], [152,167], 'indexing_cycle_range matches');} 'indexing_cycle_range lives and matches';
-  lives_ok { $long_info = test::long_info->new({runfolder_path=>$rfpath}); } q{create test role for dual index paired};
   lives_and { cmp_ok( $long_info->index_length, '==', 16, 'index_length matches');} 'index_length lives and matches';
-  lives_ok { $long_info = test::long_info->new({runfolder_path=>$rfpath}); } q{create test role for dual index paired};
   lives_and { cmp_deeply( [$long_info->read2_cycle_range], [168,318], 'read2_cycle_range matches');} 'read2_cycle_range lives and matches';
-  lives_ok { $long_info = test::long_info->new({runfolder_path=>$rfpath}); } q{create test role for dual index paired};
   lives_and { ok( $long_info->is_indexed, 'is_indexed ok');} 'is_indexed lives and ok';
-  lives_ok { $long_info = test::long_info->new({runfolder_path=>$rfpath}); } q{create test role for dual index paired};
   lives_and { ok( $long_info->is_paired_read, 'is_paired_read ok');} 'is_paired_read lives and ok';
-  lives_ok { $long_info = test::long_info->new({runfolder_path=>$rfpath}); } q{create test role for dual index paired};
   lives_and { ok( $long_info->is_dual_index, 'is_dual_index ok');} 'is_paired_read lives and ok';
-  lives_ok { $long_info = test::long_info->new({runfolder_path=>$rfpath}); } q{create test role for dual index paired};
   lives_and { cmp_deeply( [$long_info->index_read1_cycle_range], [152,159], 'index_read1_cycle_range matches');} 'index_read1_cycle_range lives and matches';
-  lives_ok { $long_info = test::long_info->new({runfolder_path=>$rfpath}); } q{create test role for dual index paired};
   lives_and { cmp_deeply( [$long_info->index_read2_cycle_range], [160,167], 'index_read2_cycle_range matches');} 'index_read2_cycle_range lives and matches';
-
   is ($long_info->instrument_name, 'M00119', 'instrument name from RunInfo.xml');
 }
 
 #and a SP flowcell
 {
-  my $long_info;
   my $rfpath = q(t/data/long_info/nfs/sf20/ILorHSany_sf20/incoming/200303_A00562_0352_AHKFVLDRXX);
-  lives_ok { $long_info = test::long_info->new({runfolder_path=>$rfpath}); }
+  my $long_info = Moose::Meta::Class->create_anon_class(
+    methods => {"runfolder_path" => sub {$rfpath}},
+    roles   => [qw/npg_tracking::illumina::run::long_info/])->new_object();
     q{create test role for SP flowcell};
   cmp_ok ( $long_info->surface_count, '==', 1, 'surface_count');
   is ($long_info->instrument_name, 'A00562', 'instrument name from RunInfo.xml');
 }
+
 1;

--- a/t/60-illumina-run-short_info.t
+++ b/t/60-illumina-run-short_info.t
@@ -1,274 +1,92 @@
 use strict;
 use warnings;
-use Test::More tests => 46;
+use Test::More tests => 5;
 use Test::Exception;
-use File::Temp qw/ tempdir /;
 use Moose::Meta::Class;
 
+use t::dbic_util;
 
-BEGIN {
-  use_ok(q{npg_tracking::illumina::run::short_info});
-}
+use_ok(q{npg_tracking::illumina::run::short_info});
 
+my $schema = t::dbic_util->new->test_schema(
+  fixture_path => q[t/data/dbic_fixtures]);
+
+my $rfname = q[20231017_LH00210_0012_B22FCNFLT3];
+
+# Start of package test::short_info
 package test::short_info;
 use Moose;
-use Carp;
-use Readonly;
-use File::Spec::Functions qw(splitdir);
-use List::Util qw(first);
-
-Readonly::Scalar my $FOLDER_PATH_PREFIX_GLOB_PATTERN => '/{staging,nfs/sf{5,6,9,10,11,12,13,14,15,16,17}}/{IL,HS}*/*/';
-
 with qw{npg_tracking::illumina::run::short_info};
 
-sub _build_run_folder {
-  my ($self) = @_;
+sub _build_run_folder { return $rfname; }
+# End of package test::short_info
 
-  if( !( $self->has_id_run() || $self->has_name() ) ) {
-    croak q{Need an id_run or name to generate the run_folder};
-  }
+# Start of package test::db_short_info
+package test::db_short_info;
+use Moose;
+use npg_tracking::Schema;
+with qw{npg_tracking::illumina::run::short_info};
 
-  my $path = $self->_short_path();
-  return first {$_ ne q()} reverse splitdir($path);
-
-}
-
-
-has q{_short_path}                => ( isa => q{Str}, is => q{ro}, lazy_build => 1, init_arg => undef );
-
-sub _build__short_path {
-  my ($self) = @_;
-  my @dir = $self->has_run_folder() ? glob $self->_folder_path_glob_pattern() . $self->run_folder()
-          : $self->has_id_run()     ? glob $self->_folder_path_glob_pattern() . q(*_{r,}) . $self->id_run() . q{*}
-          : $self->has_name()       ? glob $self->_folder_path_glob_pattern() . q{*} . $self->name()
-          :                           croak q{No run_folder, name or id_run provided}
-          ;
-
-  @dir = grep {-d $_} @dir;
-
-  if ( @dir == 0 ) {
-    croak 'No paths to run folder found.';
-  }
-
-  my %fs_inode_hash; #ignore multiple paths point to the same folder
-  @dir = grep {not $fs_inode_hash{join q(,),stat $_}++} @dir;
-
-  if ( @dir > 1 ) {
-    croak 'Ambiguous paths for run folder found: '.join q{,},@dir;
-  }
-  return shift @dir;
-}
-
-has 'pattern_prefix' => (
+has q{npg_tracking_schema} => (
+  isa => 'npg_tracking::Schema',
   is => 'ro',
-  isa => 'Str',
-  default => q[/nonexisting],
+  default => sub { return $schema },
 );
+# End of package test::db_short_info
 
-sub _folder_path_glob_pattern {
-  my $self = shift;
-  return $self->pattern_prefix . $FOLDER_PATH_PREFIX_GLOB_PATTERN;
-}
-
-
+# Start of package test::nvx_short_info
 package test::nvx_short_info;
 use Moose;
 with 'npg_tracking::illumina::run::short_info';
 
 has experiment_name => (is => 'rw');
+# End of package test::nvx_short_info
 
 package main;
 
-sub create_staging {
+subtest 'object derived directly from the role' => sub {
+  plan tests => 6;
 
-  my ($idr, $hi_seq) = @_;
-  if (!$idr) { $idr = 1234; }
-  my $base = tempdir( CLEANUP => 1 );
+  my $class = Moose::Meta::Class->create_anon_class(
+    roles => [qw/npg_tracking::illumina::run::short_info/]
+  );
 
-  my $instr_prefix = $hi_seq ? q[HS] : q[IL];
-
-  my $next = $base . q[/staging]; `mkdir $next`;
-  $next = $next . q[/] . $instr_prefix . q[2]; `mkdir $next`;
-  $next = $next . q[/analysis]; `mkdir $next`;
-  $next = $next . q[/123456_] . $instr_prefix . q[2_] . $idr;
-
-  if ( $hi_seq ) {
-    $next .= q{_B_205NNABXX};
-  }
-
-  `mkdir $next`;
-  $next = $next . q[/Data]; `mkdir $next`;
-  $next = $next . q[/Intensities]; `mkdir $next`;
-
-  my $base_calls = $next . q[/BaseCalls]; `mkdir $base_calls`;
-  my $gerald = $next . q[/Bustard-2009-10-01]; `mkdir $gerald`;
-  $gerald = $next . q[/GERALD-2009-10-01];  `mkdir $gerald`;
-
-  return $base;
-}
-
-my $id_run = q{1234};
-my $name = q{IL2_1234};
-my $run_folder = q{123456_IL2_1234};
-
-{
-  my $short_info;
-  lives_ok  { $short_info = Moose::Meta::Class->create_anon_class(
-                roles => [qw/npg_tracking::illumina::run::short_info/]
-              )->new_object({id_run => 1234});
-            } q{object directly from the role ok};
-
-  throws_ok { $short_info->run_folder(); }
-    qr{does not support builder method '_build_run_folder' for attribute 'run_folder'},
+  throws_ok { $class->new_object(id_run => 1234)->run_folder() }
+    qr{does not support builder method '_build_run_folder'},
     q{Error thrown as no _build_run_folder method in class};
-}
 
-{
-  my $short_info;
-  lives_ok  { $short_info = test::short_info->new({}); } q{no error creating no-arg test object};
-  throws_ok { $short_info->id_run();          }
-    qr{Need an id_run or name to generate the run_folder},
-    q{As run_folder, can't obtain id_run};
-  throws_ok { $short_info->name();            }
-    qr{Unable to obtain name from run_folder},
-    q{As no id_run or run_folder, can't obtain name};
-  throws_ok { $short_info->run_folder();      }
-    qr{Need an id_run or name to generate the run_folder},
-    q{As no name or id_run, can't obtain run_folder};
-  throws_ok { $short_info->_short_path();     }
-    qr{No run_folder, name or id_run provided},
-    q{As no attributes, cannot get short path};
-  throws_ok { $short_info->short_reference(); }
-    qr{Unable to obtain name from run_folder},
-    q{As no id_run or run_folder, can't obtain name};
-}
+  throws_ok { $class->new_object(run_folder => q[export/sv03/my_folder]) }
+    qr{Attribute \(run_folder\) does not pass the type constraint},
+    'error supplying a directory path as the run_folder attribute value';
 
-#### test where run_folder is given in the constructor
-{
-  my $short_info = test::short_info->new({
-    run_folder => $run_folder,
-  });
-  is($short_info->id_run(), $id_run, q{id_run worked out correctly});
-  is($short_info->name(), $name, q{name worked out correctly});
-  is($short_info->short_reference(), $run_folder, q{short_reference returns run_folder first});
+  throws_ok { $class->new_object(run_folder => q[]) }
+    qr{Attribute \(run_folder\) does not pass the type constraint},
+    'error supplying an empty atring as the run_folder attribute value';
 
-  my $hs_runfolder = q{123456_HS2_1236_B_205NNABXX};
-  $short_info = test::short_info->new({
-    run_folder => $hs_runfolder,
-  });
-  is($short_info->name(), q{HS2_1236}, q{HS name worked out correctly});
-  is($short_info->id_run(), '1236', q{HS id_run worked out correctly});
-  is($short_info->short_reference(), $hs_runfolder, q{HS short_reference returns run_folder first});
-  is( $short_info->instrument_string(), q{HS2}, q{HS instrument name correctly worked out} );
-  is( $short_info->slot(), q{B}, q{HS slot returned ok} );
-  is( $short_info->flowcell_id(), q{205NNABXX}, q{HS flowcell_id returned ok} );
-}
+  my $obj = $class->new_object(run_folder => q[my_folder], id_run => 1234);
+  is ($obj->run_folder, 'my_folder', 'the run_folder value is as set');
+  is ($obj->id_run, 1234, 'id_run value is as set');
 
-#### test where run_folder is given in the constructor
-# where we can't find out the run_folder
-{
-  my $short_info = test::short_info->new({
-    id_run => $id_run,
-  });
-  is($short_info->id_run(), $id_run, q{id_run returned correctly});
-  is($short_info->short_reference(), $id_run, q{short_reference returns id_run});
-  throws_ok { my $name = $short_info->name(); } qr{No[ ]paths[ ]to[ ]run[ ]folder[ ]found}, q{no runfolder found with which to return the path, so name/runfolder cannot be worked out};
-}
+  throws_ok { $class->new_object(run_folder => q[my_folder])->id_run }
+    qr{Unable to identify id_run with data provided},
+    'error building id_run';
+};
 
-# where we can find the run_folder
-{
-  my $base = create_staging();
-  my $short_info = test::short_info->new({
-    id_run => $id_run,
-    pattern_prefix => $base,
-  });
-  is($short_info->short_reference(), $id_run, q{short_reference returns id_run});
-  is($short_info->name(),$name, q{name worked out correctly});
-  is($short_info->short_reference(), $run_folder, q{short_reference returns run_folder});
+subtest 'object with a bulder method for run_folder' => sub {
+  plan tests => 1;
 
-  $base = create_staging(undef, 1);
-  $short_info = test::short_info->new({
-    id_run => $id_run,
-    pattern_prefix => $base,
-  });
-  is($short_info->short_reference(), $id_run, q{HS short_reference returns id_run});
-  is($short_info->name(),q{HS2_1234}, q{HS name worked out correctly});
-  is($short_info->short_reference(), q{123456_HS2_1234_B_205NNABXX}, q{HS short_reference returns run_folder});
-}
+  is (test::short_info->new(id_run => 47995)->run_folder, $rfname,
+    'value of run_folder attribute is set by the builder method');
+}; 
 
-#### test where name is give in the constructor
-{
-  my $base = create_staging();
-  my $short_info = test::short_info->new({
-    name => $name,
-    pattern_prefix => $base,
-  });
-  is($short_info->short_reference(), $name, q{short_reference returns name});
-  is($short_info->id_run(), $id_run, q{id_run worked out correctly});
-  is($short_info->short_reference(), $run_folder, q{short_reference returns run_folder});
-  is($short_info->run_folder(), $run_folder, q{run_folder worked out correctly});
-  is($short_info->short_reference(), $run_folder, q{short_reference returns run_folder});
-}
-
-
-{
-  my $id = q[01234];
-  my $base = create_staging($id);
-  my $short_info = test::short_info->new({
-    run_folder =>q{123456_IL2_01234},
-    pattern_prefix => $base,
-  });
-  is($short_info->id_run(), 1234, q{id_run worked out correctly, no leading zero});
-  is($short_info->name(), q[IL2_1234], q{name does not contain leading zero for id run});
-  is($short_info->run_folder(), q[123456_IL2_01234], q{run_folder as set});
-  is($short_info->short_reference(), q[123456_IL2_01234], q{short_reference returns run_folder});
-  is( $short_info->instrument_string(), q{IL2}, q{IL instrument name correctly worked out} );
-  is( $short_info->flowcell_id(), q{}, q{IL flowcell_id returns empty string} );
-  is( $short_info->slot(), q{}, q{IL slot returns empty string} );
-}
-
-
-{
-    my $id = q{fail};
-    my $base = create_staging($id);
-    my $short_info = test::short_info->new({
-      run_folder =>q{123456_IL2_} . $id,
-      pattern_prefix => $base,
-    });
-
-    throws_ok { $short_info->name() }
-              qr/Unrecognised format for run folder name: /ms,
-              q{croak if the run id doesn't start with an integer};
-}
-
-
-{
-    my $short_info = test::short_info->new({
-      run_folder =>q{120113_MS1_7362_A_MS0002061-300V2},
-    });
-
-    my $name;
-    my $flowcell_id;
-    lives_ok {
-      $name = $short_info->name();
-      $flowcell_id= $short_info->flowcell_id();
-    } q{MiSeq runfolder - kit id in place of flowcell};
-    is($short_info->run_folder, q(120113_MS1_7362_A_MS0002061-300V2), q(run folder okay));
-    is($name, q(MS1_7362), q(name okay));
-    is($flowcell_id, q(MS0002061-300V2), q(flowcell_id (kit id) okay));
-}
-
-subtest 'process run_folder when no id_run present' => sub {
+subtest 'object with access to tracking database' => sub {
   plan tests => 2;
-  my $run_folder = q{180517_A00512_0010_BH3WCVDSXX}; #NovaSeq folder pattern
-  my $short_info;
 
-  lives_ok {
-    $short_info = test::short_info->new({ run_folder => $run_folder });
-  } q[Can create object];
-  throws_ok  {
-    $short_info->id_run();
-  }  qr[Unable to identify id_run], q[Throws when it obtain id_run];
+  throws_ok { test::db_short_info->new(run_folder => 'xxxxxx')->id_run }
+    qr{Unable to identify id_run with data provided},
+    'error building id_run when no db record for the run folder exists';
+  is (test::db_short_info->new(run_folder => $rfname)->id_run, 47995,
+    'id_run value retrieved from the database recprd');
 };
 
 subtest 'Test id_run extraction from within experiment_name' => sub {


### PR DESCRIPTION
This is a breaking change for lots of old-fashion tests. All NPG Perl git reposhave been tested against this change. The following tests are failing in npg_seq_pipeline:
- t/10-pluggable.t                            
- t/20-function-current_analysis_link.t        
- t/20-function-seq_alignment.t                  
- t/20-function-warehouse_archiver.t             

The rest of repos are fine