### PR TITLE
manually install libmodule-runtime-perl to fix CI

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -48,7 +48,8 @@ jobs:
           sudo apt-get update
           # https://github.com/actions/runner-images/issues/2139
           sudo apt-get remove -y nginx libgd3
-          sudo apt-get install -y libgd-dev uuid-dev libgd-text-perl libdevel-patchperl-perl
+          sudo apt-get install -y libgd-dev uuid-dev libgd-text-perl libdevel-patchperl-perl \
+            libmodule-runtime-perl
 
       - name: "Cache Perl"
         id: cache-perl

--- a/Changes
+++ b/Changes
@@ -2,6 +2,7 @@ LIST OF CHANGES
 
  - Fixed perlbrew installation by installing libdevel-patchperl-perl in
    GitHub runner.
+ - Fixed CI for ubuntu 24.04 by manually installing libmodule-runtime-perl
 
 release 102.0.0 (2024-11-28)
  - Removed 'bin/npg_deletable_dr_runs' since dr storage is decommissioned


### PR DESCRIPTION
Ubuntu 24.04 is missing the package and we need it for running perl tests.