### PR TITLE
Refactored runs listing.

### DIFF
--- a/Changes
+++ b/Changes
@@ -12,6 +12,13 @@ LIST OF CHANGES
      different places in three models. In one of the models the code was never
      called, so was simply deleted.
    - Simplified the logic of retrieving cached lists and counts of runs.
+   - Dropped a custom 'read' method from npg::view::instrument. The code
+     there, which computed lists of runs and runs count is not used in the
+     template that renders an instrument. Listing of runs is implemented as
+     an iframe and therefore rendering is done by the template for listing runs.
+   - Dropped 'runs' and 'count_run' methods from npg::model::instrument, these
+     methods were only called by the deleted 'read' method from
+     npg::view::instrument
 
 release 102.1.0 (2025-01-16)
  - Fixed perlbrew installation by installing libdevel-patchperl-perl in

--- a/Changes
+++ b/Changes
@@ -3,6 +3,15 @@ LIST OF CHANGES
  - Deleted two unused methods from npg::model::instrument_annotation,
    annotations_by_instrument_over_default_uptime and
    dates_of_annotations_over_default_uptime
+ - Tracking web server:
+   - Added a new optional parameter 'manufacturer' to methods returning lists
+     of runs and run count - the name of the manufacturer. If this name is
+     undefined in the parameters hash, it defaults to 'Illumina'.
+   - To avoid code repetition, consolidated queries for listing and counting
+     runs in npg::model::run. Previously the same code was repeated in eight
+     different places in three models. In one of the models the code was never
+     called, so was simply deleted.
+   - Simplified the logic of retrieving cached lists and counts of runs.
 
 release 102.1.0 (2025-01-16)
  - Fixed perlbrew installation by installing libdevel-patchperl-perl in

--- a/data/templates/run_list.tt2
+++ b/data/templates/run_list.tt2
@@ -4,9 +4,9 @@
 <div class="roundborder">
 <div>
 <span class="page_title">Runs</span>
- &middot;&middot;<a [%target %]href="[% SCRIPT_NAME %]/run/?id_run_status_dict=all&id_instrument_format=[% model.id_instrument_format %]&id_instrument=[%id_instrument %]"  [% IF !model.id_run_status_dict || model.id_run_status_dict == 'all' %]class="runs_active_selection"[% END %]>all</a>&middot;&middot;
+ &middot;&middot;<a [%target %]href="[% SCRIPT_NAME %]/run/?id_run_status_dict=all&id_instrument_format=[% model.id_instrument_format %]&id_instrument=[%id_instrument %]&manufacturer=[% model.manufacturer %]"  [% IF !model.id_run_status_dict || model.id_run_status_dict == 'all' %]class="runs_active_selection"[% END %]>all</a>&middot;&middot;
  [% FOREACH rsd = model.current_run_status.run_status_dict.run_status_dicts_sorted -%]
-&middot;&middot;<a [%target %]href="[% SCRIPT_NAME %]/run/?id_run_status_dict=[% rsd.id_run_status_dict %]&id_instrument_format=[% model.id_instrument_format %]&id_instrument=[% id_instrument %]"><span class="npg_nbsp [% IF rsd.id_run_status_dict == model.id_run_status_dict %]runs_active_selection[% END %]">[% rsd.description %]</span></a>&middot;&middot;
+&middot;&middot;<a [%target %]href="[% SCRIPT_NAME %]/run/?id_run_status_dict=[% rsd.id_run_status_dict %]&id_instrument_format=[% model.id_instrument_format %]&id_instrument=[% id_instrument %]&manufacturer=[% model.manufacturer %]"><span class="npg_nbsp [% IF rsd.id_run_status_dict == model.id_run_status_dict %]runs_active_selection[% END %]">[% rsd.description %]</span></a>&middot;&middot;
  [% END -%]
 </div>
 [% IF !id_instrument %]
@@ -25,7 +25,7 @@
 <span class="medium_header ">Page: </span>
 [% i = 0 %]
 [% WHILE i * model.len < model.count_runs %]
-&middot;<a [% target %][% IF i == model.start / model.len%]class="active" [% END %] href="[% SCRIPT_NAME %]/[% model.table %]?id_run_status_dict=[% model.id_run_status_dict %]&len=[% model.len %]&start=[% i * model.len %]&id_instrument_format=[% model.id_instrument_format %]&id_instrument=[% id_instrument %]" id="pagination_[% i+1 %]">[% i+1 %]</a>&middot;
+&middot;<a [% target %][% IF i == model.start / model.len%]class="active" [% END %] href="[% SCRIPT_NAME %]/[% model.table %]?id_run_status_dict=[% model.id_run_status_dict %]&len=[% model.len %]&start=[% i * model.len %]&id_instrument_format=[% model.id_instrument_format %]&id_instrument=[% id_instrument %]&manufacturer=[% model.manufacturer %]" id="pagination_[% i+1 %]">[% i+1 %]</a>&middot;
 [% i = i + 1 %]
 [% END %]
 </div>

--- a/lib/npg/model/run.pm
+++ b/lib/npg/model/run.pm
@@ -34,6 +34,8 @@ Readonly::Scalar our $DEFAULT_SUMMARY_DAYS        => 14;
 Readonly::Scalar my  $FOLDER_GLOB_INDEX           => 2;
 Readonly::Scalar my  $PADDING                     => 4;
 Readonly::Hash   our %TEAMS => ('2' => 'RAD', '1' => 'A',);
+Readonly::Scalar our $DEFAULT_MANUFACTURER_NAME    => q{Illumina};
+Readonly::Scalar our $SHOW_ALL_PARAM_VALUE         => q{all};
 
 __PACKAGE__->mk_accessors(fields());
 __PACKAGE__->has_a([qw(instrument instrument_format)]);
@@ -133,83 +135,92 @@ sub end {
 
 sub runs {
   my ( $self, $params ) = @_;
+  # The run view might have cached the data.
+  return $self->{runs} ? $self->{runs} : $self->list_runs($params);
+}
 
-  $params->{id_instrument_format} ||= q{all};
+sub list_runs {
+  my ( $self, $params ) = @_;
 
-  # once we have determined this, we will set the runs to be what has been requested for the templates benefit
-  if ( $self->{runs} && ref $self->{runs} eq q{ARRAY} ) {
-    return $self->{runs};
-  }
-
-  if ( ! $self->{runs} || ref $self->{runs} ne q{HASH} ) {
-    $self->{runs} = {};
-  }
-
-  if ( $self->{runs}->{ $params->{id_instrument_format} } ) {
-    return $self->{runs}->{ $params->{id_instrument_format} };
-  }
-
-  my $pkg   = ref $self;
-  my $query = qq[SELECT @{[join q[, ], $pkg->fields()]}
-                 FROM   @{[$pkg->table()]}];
-
-  if ( $params->{id_instrument} && $params->{id_instrument} =~ /\d+/xms ) {
-    $query .= qq[ WHERE id_instrument = $params->{id_instrument}];
-  } else {
-    if ( $params->{id_instrument_format} ne q{all} && $params->{id_instrument_format} =~ /\A\d+\z/xms ) {
-      $query .= qq[ WHERE id_instrument_format = $params->{id_instrument_format}];
-    }
-  }
-  $query .= q[ ORDER BY id_run DESC];
-
-  if ( $params ) {
-    $query = $self->util->driver->bounded_select( $query,
+  my $select_count = 0;
+  my $query = $self->_create_query($select_count, $params);
+  $query .= q[ ORDER BY r.id_run DESC];
+  $query = $self->util->driver->bounded_select( $query,
                                                 $params->{len},
                                                 $params->{start});
-  }
-
-  $self->{runs}->{ $params->{id_instrument_format} } = $self->gen_getarray( $pkg, $query );
-  return $self->{runs}->{ $params->{id_instrument_format} };
+  my $pkg   = ref $self;
+  return $self->gen_getarray($pkg, $query);
 }
 
 sub count_runs {
   my ( $self, $params ) = @_;
+  # The run view might have cached the data.
+  return defined $self->{count_runs} ? $self->{count_runs} :
+    $self->get_runs_count($params);
+}
+
+sub get_runs_count {
+  my ( $self, $params ) = @_;
+
   $params ||= {};
-  $params->{id_instrument_format} ||= q{all};
-
-  # once we have determined this, we will set the runs to be what has been requested for the templates benefit
-  if ( defined $self->{count_runs} && ! ref $self->{count_runs} ) {
-    return $self->{count_runs};
-  }
-
-  if ( ! $self->{count_runs} || ref $self->{count_runs} ne q{HASH} ) {
-    $self->{count_runs} = {};
-  }
-
-  if ( defined $self->{count_runs}->{ $params->{id_instrument_format} } ) {
-    return $self->{count_runs}->{ $params->{id_instrument_format} };
-  }
-
-  my $pkg   = ref $self;
-  my $query = qq[SELECT COUNT(*)
-                 FROM   @{[$pkg->table()]}];
-
-  if ( $params->{id_instrument} && $params->{id_instrument} =~ /\d+/xms ) {
-    $query .= qq[ WHERE id_instrument = $params->{id_instrument}];
-  } else {
-    if ( $params->{id_instrument_format} ne q{all} && $params->{id_instrument_format} =~ /\A\d+\z/xms ) {
-      $query .= qq[ WHERE id_instrument_format = $params->{id_instrument_format}];
-    }
-  }
-
+  my $select_count = 1;
+  my $query = $self->_create_query($select_count, $params);
   my $ref = $self->util->dbh->selectall_arrayref( $query );
-  if( defined $ref->[0] &&
-      defined $ref->[0]->[0] ) {
-    $self->{count_runs}->{ $params->{id_instrument_format} } = $ref->[0]->[0];
+  if ( defined $ref->[0] && defined $ref->[0]->[0] ) {
     return $ref->[0]->[0];
   }
 
   return;
+}
+
+sub _create_query {
+  my ($self, $select_count, $params) = @_;
+
+  my $id_instr_format = $params->{id_instrument_format};
+  $id_instr_format ||= $SHOW_ALL_PARAM_VALUE;
+  my $manufacturer_name = $params->{manufacturer};
+  $manufacturer_name ||= $DEFAULT_MANUFACTURER_NAME;
+  my $id_instr = $params->{id_instrument};
+  my $id_status_dict = $params->{id_run_status_dict};
+
+  my $pkg = ref $self;
+  my $query = sprintf 'SELECT %s FROM %s AS r',
+    $select_count ? q[COUNT(*)] : join(q[, ], map { q[r.] . $_ } $pkg->fields()),
+    $pkg->table();
+
+  my @where = ();
+  # If run info for a particular instrument is requested, disregard the
+  # instrument format and the manufacturer.
+  if ( $id_instr && $id_instr =~ /\d+/xms ) {
+    push @where, qq[r.id_instrument = $id_instr];
+  } else {
+    # If run info for a particular instrument format is requested, disregard
+    # the manufacturer.
+    if ( $id_instr_format =~ /\A\d+\z/xms ) {
+      push @where, qq[r.id_instrument_format = $id_instr_format];
+    }
+    # If runs from a particular manufacturer are requested, select
+    # on manufacturer name.
+    if ( $manufacturer_name ne $SHOW_ALL_PARAM_VALUE ) {
+      $query .= ' JOIN instrument_format AS inf' .
+                ' ON r.id_instrument_format=inf.id_instrument_format' .
+                ' JOIN manufacturer AS m' .
+                ' ON inf.id_manufacturer=m.id_manufacturer';
+      push @where, qq[m.name = '$manufacturer_name'];
+    }
+  }
+
+  # Filter by current run status.
+  if ( $id_status_dict && ($id_status_dict ne $SHOW_ALL_PARAM_VALUE) ) {
+    $query .= ' JOIN run_status AS rs ON r.id_run=rs.id_run';
+    push @where, qq[rs.id_run_status_dict=$id_status_dict AND rs.iscurrent=1];
+  }
+
+  if (@where) {
+    $query .= ' WHERE ' . join ' AND ', @where;
+  }
+
+  return $query;
 }
 
 sub current_run_status {
@@ -1053,16 +1064,31 @@ npg::model::run
 
 =head2 runs - arrayref of all npg::model::runs
 
-  my $arAllRuns = $oRun->runs();
+  my $arRuns = $oRun->runs($params);
 
-  my $arRunsBounded = $oRun->runs({
-    len   => 10,
-    start => 20,
-  };
+  Returns a list of cached run models or retrieves a new list in accordance with
+  the parameters of the query, see C<get_runs>. Bounds the retrieved list
+  according to C<start> and C<len> parameters.
 
-=head2 count_runs - count of runs for this instrument
+=head2 list_runs - arrayref of all npg::model::runs
 
-  my $iRunCount = $oRun->count_runs();
+  my $arRuns = $oRun->list_runs($params);
+
+  Retrieves and returns a list or run models in accordance with the parameters
+  of the query.
+
+=head2 count_runs
+
+  my $iRunCount = $oRun->count_runs($params);
+
+  Returns a cached value or retrieves a new one in accordance with
+  the parameters of the query, see C<get_runs_count>.
+
+=head2 get_runs_count
+
+  my $iRunCount = $oRun->count_runs($params);
+
+  Returns the cout of runs according to the parameters of the query.
 
 =head2 runs_on_batch
 
@@ -1251,7 +1277,7 @@ $instruments is undefined
 
 =head1 LICENSE AND COPYRIGHT
 
-Copyright (C) 2006-2012,2013,2014,2015,2016,2017,2020, 2021 Genome Research Ltd.
+Copyright (C) 2006-2012, 2013,2014,2015,2016,2017,2020,2021,2022,2025 Genome Research Ltd.
 
 This file is part of NPG.
 

--- a/lib/npg/view/instrument.pm
+++ b/lib/npg/view/instrument.pm
@@ -1,18 +1,7 @@
-#########
-# Author:        rmp
-# Created:       2007-03-28
-#
 package npg::view::instrument;
 
 use strict;
 use warnings;
-use base qw(npg::view);
-use npg::model::instrument;
-use npg::model::instrument_format;
-use npg::model::instrument_status;
-use npg::model::instrument_status_dict;
-use npg::model::run_status_dict;
-use npg::model::instrument_status_dict;
 use GD;
 use GD::Text;
 use Carp;
@@ -22,11 +11,16 @@ use List::MoreUtils qw(any);
 use DateTime::Format::MySQL;
 use DateTime;
 
+use npg::model::instrument;
+use npg::model::instrument_format;
+use npg::model::instrument_status;
+use npg::model::instrument_status_dict;
+
+use base qw(npg::view);
+
 our $VERSION = '0';
 ##no critic(ProhibitManyArgs ProhibitMagicNumbers)
 
-Readonly::Scalar our $PAGINATION_LEN   => 40;
-Readonly::Scalar our $PAGINATION_START => 0;
 Readonly::Scalar our $IMAGE_DIMENSIONS            => 110;
 Readonly::Scalar our $FILLED_RECTANGLE_INFO       => 80;
 Readonly::Scalar our $FILLED_RECTANGLE_TWO        => 66;
@@ -151,37 +145,6 @@ sub list_edit_statuses {
   $self->model->{instrument_mod_dicts} = $root_imd->instrument_mod_dicts();
 
   return $self->list(@args);
-}
-
-sub read { ## no critic (ProhibitBuiltinHomonyms)
-  my $self    = shift;
-  my $util    = $self->util();
-  my $cgi     = $util->cgi();
-  my $model   = $self->model();
-  my $aspect  = $self->aspect();
-  my $session = $util->session();
-  my $len     = $cgi->param('len')   || $PAGINATION_LEN;
-  my $start   = $cgi->param('start') || $PAGINATION_START;
-  my $id_rsd  = $cgi->param('id_run_status_dict') || $session->{id_run_status_dict} || 'all';
-  my $all_rsd = npg::model::run_status_dict->new({
-              util => $util,
-             })->run_status_dicts();
-
-  $model->{start}            = $start;
-  $model->{len}              = $len;
-  $model->{run_status_dicts} = $all_rsd;
-
-  $model->{runs} = $model->runs({
-         len                => $len,
-         start              => $start,
-         id_run_status_dict => ($id_rsd ne 'all')?$id_rsd:undef,
-        });
-  $model->{count_runs} = $model->count_runs({id_run_status_dict => ($id_rsd ne 'all')?$id_rsd:undef});
-
-  $model->{id_run_status_dict}   = $id_rsd;
-  $session->{id_run_status_dict} = $id_rsd;
-
-  return 1;
 }
 
 sub read_key_png {
@@ -568,8 +531,6 @@ npg::view::instrument - view handling for instruments
 
 =head2 list_graphical - handling for graphical listings
 
-=head2 read - additional handling for listing runs by status
-
 =head2 read_png - annotated instrument graphic
 
 =head2 read_key_png - special case handling for instrument of id 'key'
@@ -628,11 +589,17 @@ npg::view::instrument - view handling for instruments
 
 =head1 AUTHOR
 
-Roger Pettett, E<lt>rmp@sanger.ac.ukE<gt>
+=over
+
+=item Roger Pettett
+
+=item Marina Gourtovaia
+
+=back
 
 =head1 LICENSE AND COPYRIGHT
 
-Copyright (C) 2008 GRL, by Roger Pettett
+Copyright (C) 2007-2012,2013,2014,2016,2017,2018,2019,2022,2023,2025 Genome Research Ltd.
 
 This file is part of NPG.
 

--- a/lib/npg/view/run.pm
+++ b/lib/npg/view/run.pm
@@ -1,26 +1,25 @@
-#########
-# Author:        rmp
-# Created:       2007-03-28
-#
 package npg::view::run;
-use base qw(npg::view);
+
 use strict;
 use warnings;
 use Carp;
 use English qw(-no_match_vars);
+use POSIX qw(strftime);
+use Socket;
+
 use npg::model::run_status_dict;
 use npg::model::instrument;
 use npg::model::run_lane;
 use npg::model::run;
-use POSIX qw(strftime);
-use Socket;
-use Readonly;
+
+use base qw(npg::view);
 
 our $VERSION = '0';
 
 Readonly::Scalar our $PAGINATION_LEN   => 40;
 Readonly::Scalar our $PAGINATION_START => 0;
 Readonly::Scalar my  $DAYS_IN_WEEK     => 14;
+Readonly::Scalar my  $DEFAULT_RUN_STATUS => 'run pending';
 
 sub new {
   my ($class, @args) = @_;
@@ -46,7 +45,7 @@ sub authorised {
   my $aspect = $self->aspect() || q[];
 
   #########
-  # Allow loaders the ability to create runs
+  # Allow loaders to create runs.
   #
   if ( ( $aspect eq 'add' || $aspect eq 'add_pair_ajax' ) && $requestor->is_member_of('loaders') ) {return 1;}
 
@@ -78,7 +77,7 @@ sub read { ## no critic (ProhibitBuiltinHomonyms)
   }
 
   #########
-  # override id_run_pair (which will be empty for R1) using the id_run of any
+  # Override id_run_pair (which will be empty for R1) using the id_run of any
   # existing second end
   #
   $model->{id_run_pair} = $model->run_pair() ? $model->run_pair->id_run() : 0;
@@ -155,62 +154,44 @@ sub list {
   my $self       = shift;
   my $util       = $self->util();
   my $cgi        = $util->cgi();
-  my $session    = $util->session();
-  my $len        = $cgi->param('len')   || $PAGINATION_LEN;
-  my $start      = $cgi->param('start') || $PAGINATION_START;
-  my $batch_id   = $cgi->param('batch_id');
-  my $id_rsd     = $cgi->param('id_run_status_dict');
-
-  my $id_instrument_format = $cgi->param( q{id_instrument_format} ) || q{all};
-  my $id_instrument = $cgi->param( q{id_instrument} );
 
   my $model      = $self->model();
-  my $aspect     = $self->aspect();
+  my $batch_id = $cgi->param('batch_id');
 
-  $model->{start} = $start;
-  $model->{len}   = $len;
-
-  my $ref = {
-     len   => $len,
-     start => $start,
-     id_instrument_format => $id_instrument_format,
-  };
-  my $rsd_ref = { id_instrument_format => $id_instrument_format,};
-  if ($id_instrument) {
-    $ref->{id_instrument} = $id_instrument;
-    $rsd_ref->{id_instrument} = $id_instrument;
-  };
-
-  if ( $batch_id ) {
-    $model->{runs} = $model->runs_on_batch( $batch_id );
-  } elsif ( $id_rsd ) {
-    if ( $id_rsd eq 'all' ) {
-      $model->{runs} = $model->runs($ref);
-      $model->{count_runs} = $model->count_runs($rsd_ref);
-    } else {
-      my $rsd = npg::model::run_status_dict->new( {
-        util               => $util,
-        id_run_status_dict => $id_rsd,
-      } );
-      $model->{runs} = $rsd->runs($ref);
-      $model->{count_runs} = $rsd->count_runs($rsd_ref);
-    }
+  if ( $batch_id ) { # Most likely this request comes from the search utility.
+    $model->{runs} = $model->runs_on_batch($batch_id);
   } else {
-    my $rsd = npg::model::run_status_dict->new( {
-      util        => $util,
-      description => 'run pending',  # Default to pending runs
-    } );
-    $model->{runs} = $rsd->runs($ref);
-    $model->{count_runs} = $rsd->count_runs($rsd_ref);
-    $id_rsd = $rsd->id_run_status_dict();
-  }
-  if ( $id_rsd ) {
-    $model->{id_run_status_dict} = $id_rsd;
-  }
-  $model->{id_instrument_format} = $id_instrument_format;
-  if ($id_instrument) {
-    $self->{no_main_menu} = 1;
-    $model->{id_instrument} = $id_instrument;
+
+    my $params = {};
+    for my $p (qw/len start
+                  id_instrument_format id_instrument manufacturer
+                  id_run_status_dict/) {
+      $params->{$p} = $cgi->param($p);
+    }
+    $params->{len} ||= $PAGINATION_LEN;
+    $params->{start} ||= $PAGINATION_START;
+    $params->{id_instrument_format} ||= $npg::model::run::SHOW_ALL_PARAM_VALUE;
+    $params->{manufacturer} ||= $npg::model::run::DEFAULT_MANUFACTURER_NAME;
+
+    if ( !$params->{id_run_status_dict} ) {
+      $params->{id_run_status_dict} = npg::model::run_status_dict->new({
+        util        => $util,
+        description => $DEFAULT_RUN_STATUS,
+      })->id_run_status_dict();
+    }
+
+    $model->{runs} = $model->runs($params);
+    $model->{count_runs} = $model->count_runs($params);
+
+    $model->{id_run_status_dict} = $params->{id_run_status_dict};
+    $model->{start} = $params->{start};
+    $model->{len}   = $params->{len};
+    $model->{id_instrument_format} = $params->{id_instrument_format};
+    $model->{manufacturer} = $params->{manufacturer};
+    if ($params->{id_instrument}) { # For 'Runs' tab on an instrument page.
+      $self->{no_main_menu} = 1;
+      $model->{id_instrument} = $params->{id_instrument};
+    }
   }
 
   return 1;
@@ -279,7 +260,7 @@ sub create {
          sort { $a <=> $b } keys %{$lanes}];
 
   #########
-  # fake the cgi id_user parameter based on requestor's id_user
+  # Fake the cgi id_user parameter based on requestor's id_user
   # so that model::run->create is able to find it for its new xrun_status
   #
   $model->id_user($util->requestor->id_user());
@@ -463,11 +444,17 @@ handling for the stuck runs page
 
 =head1 AUTHOR
 
-Roger Pettett, E<lt>rmp@sanger.ac.ukE<gt>
+=over
+
+=item Roger Pettett
+
+=item Marina Gourtovaia
+
+=back
 
 =head1 LICENSE AND COPYRIGHT
 
-Copyright (C) 2017 GRL
+Copyright (C) 2007-2012,2013,2014,2016,2017,2021,2025 Genome Research Ltd.
 
 This file is part of NPG.
 

--- a/t/10-model-instrument.t
+++ b/t/10-model-instrument.t
@@ -1,94 +1,14 @@
 use strict;
 use warnings;
-use t::util;
-use Test::More tests => 142;
+use Test::More tests => 126;
 use Test::Deep;
 use Test::Exception;
 
-use_ok('npg::model::instrument');
+use t::util;
 
 my $util = t::util->new({ fixtures => 1 });
 
-{
-  my $inst = npg::model::instrument->new({
-            id_instrument => 3,
-            util          => $util,
-           });
-  my $runs = $inst->runs();
-  is((scalar @{$runs}), 12, 'all runs for instrument');
-}
-
-{
-  my $inst = npg::model::instrument->new({
-            id_instrument => 3,
-            util          => $util,
-           });
-  my $runs = $inst->runs({len => 4});
-  is((scalar @{$runs}), 4, 'limited all runs for instrument');
-  is($runs->[0]->id_run(), 12, 'first run ok');
-}
-
-{
-  my $inst = npg::model::instrument->new({
-            id_instrument => 3,
-            util          => $util,
-           });
-  my $runs = $inst->runs({
-        len   => 4,
-        start => 1,
-       });
-  is((scalar @{$runs}), 4, 'limited, offset all runs for instrument');
-  is($runs->[0]->id_run(), 11, 'first run ok');
-}
-
-{
-  my $inst = npg::model::instrument->new({
-            id_instrument => 3,
-            util          => $util,
-           });
-  my $runs = $inst->runs({
-        id_run_status_dict => 11,
-       });
-  is((scalar @{$runs}), 3, 'id_rsd-restricted runs for instrument');
-}
-
-{
-  my $inst = npg::model::instrument->new({
-            id_instrument => 3,
-            util          => $util,
-           });
-  my $runs = $inst->runs({
-        id_run_status_dict => 11,
-        len => 2,
-       });
-  is((scalar @{$runs}), 2, 'limited, id_rsd-restricted runs for instrument');
-  is($runs->[0]->id_run(), 5, 'first run ok');
-  is($runs->[1]->id_run(), 12, 'second run ok');
-}
-
-{
-  my $inst = npg::model::instrument->new({
-            id_instrument => 3,
-            util          => $util,
-           });
-  my $runs = $inst->runs({
-        id_run_status_dict => 11,
-        len   => 2,
-        start => 1,
-       });
-  is((scalar @{$runs}), 2, 'limited, offset, id_rsd-restricted runs for instrument');
-  is($runs->[0]->id_run(), 12, 'first run ok');
-  is($runs->[1]->id_run(), 11, 'second run ok');
-}
-
-{
-  my $inst = npg::model::instrument->new({
-            id_instrument => 3,
-            util          => $util,
-           });
-  is($inst->count_runs(), 12);
-  is($inst->count_runs({id_run_status_dict=>11}), 3);
-}
+use_ok('npg::model::instrument');
 
 {
   my $model = npg::model::instrument->new({
@@ -133,10 +53,6 @@ my $util = t::util->new({ fixtures => 1 });
              util          => $util,
              id_instrument => 4,
             });
-  my $runs = $model->runs();
-  isa_ok($runs, 'ARRAY', '$model->runs()');
-  isa_ok($runs->[0], 'npg::model::run', '$model->runs()->[0]');
-
   my $current_run = $model->current_run();
   isa_ok($current_run, 'npg::model::run', '$model->current_run()');
   is($model->current_run(), $current_run, '$model->current_run() cached ok');

--- a/t/10-model-run.t
+++ b/t/10-model-run.t
@@ -85,7 +85,7 @@ subtest 'runs on batch' => sub {
 };
 
 subtest 'listing runs' => sub {
-  plan tests => 6;
+  plan tests => 25;
 
   my $model = npg::model::run->new({util => $util});
   my $runs = $model->runs();
@@ -103,6 +103,74 @@ subtest 'listing runs' => sub {
   $got = $run2->id_run;
   is($got, 15, 'correct id_run for the 10th run');
   is($run2->name(), 'IL10_0015', "correct run name for run $got");
+
+  $model = npg::model::run->new({util => $util});
+  my $params = {id_run_status_dict => 9}; # analysis complete
+  $runs = $model->runs($params);
+  is((scalar @{$runs}), 2, 'two runs');
+  is($model->count_runs($params), 2, 'run count is correct');
+
+  $model = npg::model::run->new({util => $util});
+  $params = {id_run_status_dict => 11, len => 2}; # run mirrored
+  my $first_two = $model->runs($params); 
+  is((scalar @{$first_two}),     2, 'first two runs');
+  is($first_two->[0]->id_run(), 12, 'first run id');
+  is($first_two->[1]->id_run(), 11, 'second run id');
+  is($model->count_runs($params), 3, 'correct run count');
+
+  $model = npg::model::run->new({util => $util});
+  $params = {id_run_status_dict => 11, len => 2, start => 1};
+  my $second_two = $model->runs($params);
+  is((scalar @{$second_two}),     2, 'second two runs for id_rsd 11');
+  is($second_two->[0]->id_run(), 11, 'second run id');
+  is($second_two->[1]->id_run(), 5,  'third run id');
+
+  $model = npg::model::run->new({util => $util});
+  $params = {id_run_status_dict => 4, id_instrument_format => 10}; # run complete
+  is($model->count_runs($params), 3, 'run count is correct');
+
+  $model = npg::model::run->new({util => $util});
+  $params = {id_run_status_dict => 4, id_instrument_format => 7};
+  is($model->count_runs($params), 1, 'correct run count');
+
+  $model = npg::model::run->new({util => $util});
+  $params = {id_run_status_dict => 'all', id_instrument_format => 'all'};
+  is($model->count_runs($params), 24, 'correct overall Illumina run count');
+
+  $model = npg::model::run->new({util => $util});
+  $params = {id_run_status_dict => 'all',
+             id_instrument_format => 'all',
+             manufacturer => 'Applied Biosystems'};
+  is($model->count_runs($params), 0, 'correct run count');
+
+  $model = npg::model::run->new({util => $util});
+  $params = {id_run_status_dict => 'all',
+             id_instrument_format => 10,
+             manufacturer => 'Illumina',
+             id_instrument => 4};
+  # id_instrument_format is 4 for this instrument
+  # instrument id takes precedence over instrument format
+  is($model->count_runs($params), 3, 'correct count');
+
+  $model = npg::model::run->new({util => $util});
+  $params = {id_run_status_dict => 'all',
+             id_instrument_format => 4,
+             manufacturer => 'Applied Biosystems',
+             id_instrument => 4};
+  # instrument id takes precedence over manufacturer
+  is($model->count_runs($params), 3, 'correct count');
+
+  $model = npg::model::run->new({util => $util});
+  $params = {id_run_status_dict => 2,
+             id_instrument => 4};
+  is($model->count_runs($params), 1, 'correct count');
+  is($model->runs($params)->[0]->id_run(), 13, 'correct run id');
+
+  $model = npg::model::run->new({util => $util});
+  $params = {id_run_status_dict => 1,
+             id_instrument => 4};
+  is($model->count_runs($params), 0, 'correct count');
+  is(scalar @{$model->runs($params)}, 0, 'an empty list of runs');
 };
 
 {
@@ -612,12 +680,12 @@ subtest 'run creation error due to problems with batch id' => sub {
 };
 {
   my $model = npg::model::run->new({});
-  dies_ok{ $model->get_instruments }, "Accessing undefined instruments ArrayRef fails";
+  dies_ok{ $model->get_instruments }, 'Accessing undefined instruments ArrayRef fails';
 
   $model = npg::model::run->new({
     instruments => \(t::instrument->new(name => "NV1")),
   });
-  lives_ok{ $model->get_instruments }, "Accessing defined instruments ArrayRef succeeds";
+  lives_ok{ $model->get_instruments }, 'Accessing defined instruments ArrayRef succeeds';
 }
 
 {

--- a/t/10-model-run_status_dict.t
+++ b/t/10-model-run_status_dict.t
@@ -1,11 +1,7 @@
 use strict;
 use warnings;
 use t::util;
-use npg::model::instrument;
-use npg::model::user;
-use npg::model::annotation;
-use Test::More tests => 25;
-use Test::Deep;
+use Test::More tests => 8;
 
 use_ok('npg::model::run_status_dict');
 
@@ -36,7 +32,6 @@ my $util = t::util->new({fixtures=>1});
 
   isa_ok($rsds, 'ARRAY');
   is((scalar @{$rsds}), 24, 'all run status dicts');
-
 }
 
 {
@@ -52,73 +47,9 @@ my $util = t::util->new({fixtures=>1});
 
   my @sorted_run_status_dicts = sort {
     $a->{temporal_index} <=> $b->{temporal_index}
-  }
-  @{$rsds};
+  } @{$rsds};
 
-  cmp_deeply($rsds, \@sorted_run_status_dicts, 'Status list is in temporal index order');
+  is_deeply($rsds, \@sorted_run_status_dicts, 'Status list is in temporal index order');
 }
 
-{
-  my $rsd = npg::model::run_status_dict->new({
-                util        => $util,
-                description => 'analysis complete',
-               });
-  my $runs = $rsd->runs();
-  isa_ok($runs, 'ARRAY');
-  is((scalar @{$runs}), 2, 'unprimed cache runs');
-
-  my $runs2 = $rsd->runs();
-  isa_ok($runs2, 'ARRAY');
-  is((scalar @{$runs2}), 2, 'primed cache runs');
-}
-
-{
-  my $rsd = npg::model::run_status_dict->new({
-                util               => $util,
-                id_run_status_dict => 11,
-               });
-  my $first_two = $rsd->runs({len => 2});
-  is((scalar @{$first_two}),     2, 'first two runs for id_rsd 11');
-  is($first_two->[0]->id_run(), 12, 'first run id for id_rsd 11');
-  is($first_two->[1]->id_run(), 11, 'second run id ');
-
-  my $second_two = $rsd->runs({
-             len   => 2,
-             start => 1,
-            });
-  is((scalar @{$second_two}),     2, 'second two runs for id_rsd 11');
-  is($second_two->[0]->id_run(), 11, 'second run id');
-  is($second_two->[1]->id_run(), 5,  'third run id');
-
-  is((scalar @{$rsd->runs()}), 3, 'run list unmodified');
-}
-
-{
-  my $rsd = npg::model::run_status_dict->new({
-                util        => $util,
-                description => 'analysis complete',
-               });
-  my $count_runs = $rsd->count_runs();
-  is($count_runs, 2, 'unprimed cache count_runs - analysis complete - all formats');
-  is($count_runs, 2, 'primed cache count_runs - analysis complete - all formats');
-}
-{
-
-  my $rsd = npg::model::run_status_dict->new({
-                util        => $util,
-                description => 'run complete',
-               });
-
-  my $count_runs = $rsd->count_runs( {
-    id_instrument_format => 10,
-  } );
-  is($count_runs, 3, 'unprimed cache count_runs(3) - run complete - id_instrument_format = 10');
-  is($count_runs, 3, 'primed cache count_runs(3) - run complete - id_instrument_format = 10');
-
-  $count_runs = $rsd->count_runs( {
-    id_instrument_format => 7,
-  } );
-  is($count_runs, 1, 'unprimed cache count_runs(1) - run complete - id_instrument_format = 7');
-  is($count_runs, 1, 'primed cache count_runs(1) - run complete - id_instrument_format = 7');
-
-}
+1;

--- a/t/20-view-run.t
+++ b/t/20-view-run.t
@@ -155,9 +155,10 @@ my $util = t::util->new({fixtures  => 1,});
            REQUEST_METHOD => 'GET',
            username       => 'public',
            util           => $util,
-           cgi_params     => {id_run_status_dict => 'all', id_instrument => 3, },
+           cgi_params     => {id_run_status_dict => 'all', id_instrument => 3,},
           });
-  ok($util->test_rendered($str, 't/data/rendered/run/runs_on_instrument.html'), 'html list render run instrument 3 all statuses');
+  ok($util->test_rendered($str, 't/data/rendered/run/runs_on_instrument.html'),
+    'html list render run instrument 3 all run statuses');
 }
 
 {  

--- a/t/data/rendered/run.html
+++ b/t/data/rendered/run.html
@@ -1,28 +1,28 @@
 <div class="roundborder">
  <div>
  <span class="page_title">Runs</span>
-  &middot;&middot;<a href="/cgi-bin/npg/run/?id_run_status_dict=all&id_instrument_format=all&id_instrument="  >all</a>&middot;&middot;
-  &middot;&middot;<a href="/cgi-bin/npg/run/?id_run_status_dict=1&id_instrument_format=all&id_instrument="><span class="npg_nbsp runs_active_selection">run pending</span></a>&middot;&middot;
-  &middot;&middot;<a href="/cgi-bin/npg/run/?id_run_status_dict=3&id_instrument_format=all&id_instrument="><span class="npg_nbsp ">run on hold</span></a>&middot;&middot;
-  &middot;&middot;<a href="/cgi-bin/npg/run/?id_run_status_dict=2&id_instrument_format=all&id_instrument="><span class="npg_nbsp ">run in progress</span></a>&middot;&middot;
-  &middot;&middot;<a href="/cgi-bin/npg/run/?id_run_status_dict=22&id_instrument_format=all&id_instrument="><span class="npg_nbsp ">run stopped early</span></a>&middot;&middot;
-  &middot;&middot;<a href="/cgi-bin/npg/run/?id_run_status_dict=5&id_instrument_format=all&id_instrument="><span class="npg_nbsp ">run cancelled</span></a>&middot;&middot;
-  &middot;&middot;<a href="/cgi-bin/npg/run/?id_run_status_dict=4&id_instrument_format=all&id_instrument="><span class="npg_nbsp ">run complete</span></a>&middot;&middot;
-  &middot;&middot;<a href="/cgi-bin/npg/run/?id_run_status_dict=11&id_instrument_format=all&id_instrument="><span class="npg_nbsp ">run mirrored</span></a>&middot;&middot;
-  &middot;&middot;<a href="/cgi-bin/npg/run/?id_run_status_dict=6&id_instrument_format=all&id_instrument="><span class="npg_nbsp ">analysis pending</span></a>&middot;&middot;
-  &middot;&middot;<a href="/cgi-bin/npg/run/?id_run_status_dict=21&id_instrument_format=all&id_instrument="><span class="npg_nbsp ">data discarded</span></a>&middot;&middot;
-  &middot;&middot;<a href="/cgi-bin/npg/run/?id_run_status_dict=7&id_instrument_format=all&id_instrument="><span class="npg_nbsp ">analysis in progress</span></a>&middot;&middot;
-  &middot;&middot;<a href="/cgi-bin/npg/run/?id_run_status_dict=24&id_instrument_format=all&id_instrument="><span class="npg_nbsp ">secondary analysis in progress</span></a>&middot;&middot;
-  &middot;&middot;<a href="/cgi-bin/npg/run/?id_run_status_dict=8&id_instrument_format=all&id_instrument="><span class="npg_nbsp ">analysis on hold</span></a>&middot;&middot;
-  &middot;&middot;<a href="/cgi-bin/npg/run/?id_run_status_dict=10&id_instrument_format=all&id_instrument="><span class="npg_nbsp ">analysis cancelled</span></a>&middot;&middot;
-  &middot;&middot;<a href="/cgi-bin/npg/run/?id_run_status_dict=9&id_instrument_format=all&id_instrument="><span class="npg_nbsp ">analysis complete</span></a>&middot;&middot;
-  &middot;&middot;<a href="/cgi-bin/npg/run/?id_run_status_dict=19&id_instrument_format=all&id_instrument="><span class="npg_nbsp ">qc review pending</span></a>&middot;&middot;
-  &middot;&middot;<a href="/cgi-bin/npg/run/?id_run_status_dict=26&id_instrument_format=all&id_instrument="><span class="npg_nbsp ">qc in progress</span></a>&middot;&middot;
-  &middot;&middot;<a href="/cgi-bin/npg/run/?id_run_status_dict=25&id_instrument_format=all&id_instrument="><span class="npg_nbsp ">qc on hold</span></a>&middot;&middot;
-  &middot;&middot;<a href="/cgi-bin/npg/run/?id_run_status_dict=17&id_instrument_format=all&id_instrument="><span class="npg_nbsp ">archival pending</span></a>&middot;&middot;
-  &middot;&middot;<a href="/cgi-bin/npg/run/?id_run_status_dict=18&id_instrument_format=all&id_instrument="><span class="npg_nbsp ">archival in progress</span></a>&middot;&middot;
-  &middot;&middot;<a href="/cgi-bin/npg/run/?id_run_status_dict=12&id_instrument_format=all&id_instrument="><span class="npg_nbsp ">run archived</span></a>&middot;&middot;
-  &middot;&middot;<a href="/cgi-bin/npg/run/?id_run_status_dict=20&id_instrument_format=all&id_instrument="><span class="npg_nbsp ">qc complete</span></a>&middot;&middot;
+  &middot;&middot;<a href="/cgi-bin/npg/run/?id_run_status_dict=all&id_instrument_format=all&id_instrument=&manufacturer=Illumina"  >all</a>&middot;&middot;
+  &middot;&middot;<a href="/cgi-bin/npg/run/?id_run_status_dict=1&id_instrument_format=all&id_instrument=&manufacturer=Illumina"><span class="npg_nbsp runs_active_selection">run pending</span></a>&middot;&middot;
+  &middot;&middot;<a href="/cgi-bin/npg/run/?id_run_status_dict=3&id_instrument_format=all&id_instrument=&manufacturer=Illumina"><span class="npg_nbsp ">run on hold</span></a>&middot;&middot;
+  &middot;&middot;<a href="/cgi-bin/npg/run/?id_run_status_dict=2&id_instrument_format=all&id_instrument=&manufacturer=Illumina"><span class="npg_nbsp ">run in progress</span></a>&middot;&middot;
+  &middot;&middot;<a href="/cgi-bin/npg/run/?id_run_status_dict=22&id_instrument_format=all&id_instrument=&manufacturer=Illumina"><span class="npg_nbsp ">run stopped early</span></a>&middot;&middot;
+  &middot;&middot;<a href="/cgi-bin/npg/run/?id_run_status_dict=5&id_instrument_format=all&id_instrument=&manufacturer=Illumina"><span class="npg_nbsp ">run cancelled</span></a>&middot;&middot;
+  &middot;&middot;<a href="/cgi-bin/npg/run/?id_run_status_dict=4&id_instrument_format=all&id_instrument=&manufacturer=Illumina"><span class="npg_nbsp ">run complete</span></a>&middot;&middot;
+  &middot;&middot;<a href="/cgi-bin/npg/run/?id_run_status_dict=11&id_instrument_format=all&id_instrument=&manufacturer=Illumina"><span class="npg_nbsp ">run mirrored</span></a>&middot;&middot;
+  &middot;&middot;<a href="/cgi-bin/npg/run/?id_run_status_dict=6&id_instrument_format=all&id_instrument=&manufacturer=Illumina"><span class="npg_nbsp ">analysis pending</span></a>&middot;&middot;
+  &middot;&middot;<a href="/cgi-bin/npg/run/?id_run_status_dict=21&id_instrument_format=all&id_instrument=&manufacturer=Illumina"><span class="npg_nbsp ">data discarded</span></a>&middot;&middot;
+  &middot;&middot;<a href="/cgi-bin/npg/run/?id_run_status_dict=7&id_instrument_format=all&id_instrument=&manufacturer=Illumina"><span class="npg_nbsp ">analysis in progress</span></a>&middot;&middot;
+  &middot;&middot;<a href="/cgi-bin/npg/run/?id_run_status_dict=24&id_instrument_format=all&id_instrument=&manufacturer=Illumina"><span class="npg_nbsp ">secondary analysis in progress</span></a>&middot;&middot;
+  &middot;&middot;<a href="/cgi-bin/npg/run/?id_run_status_dict=8&id_instrument_format=all&id_instrument=&manufacturer=Illumina"><span class="npg_nbsp ">analysis on hold</span></a>&middot;&middot;
+  &middot;&middot;<a href="/cgi-bin/npg/run/?id_run_status_dict=10&id_instrument_format=all&id_instrument=&manufacturer=Illumina"><span class="npg_nbsp ">analysis cancelled</span></a>&middot;&middot;
+  &middot;&middot;<a href="/cgi-bin/npg/run/?id_run_status_dict=9&id_instrument_format=all&id_instrument=&manufacturer=Illumina"><span class="npg_nbsp ">analysis complete</span></a>&middot;&middot;
+  &middot;&middot;<a href="/cgi-bin/npg/run/?id_run_status_dict=19&id_instrument_format=all&id_instrument=&manufacturer=Illumina"><span class="npg_nbsp ">qc review pending</span></a>&middot;&middot;
+  &middot;&middot;<a href="/cgi-bin/npg/run/?id_run_status_dict=26&id_instrument_format=all&id_instrument=&manufacturer=Illumina"><span class="npg_nbsp ">qc in progress</span></a>&middot;&middot;
+  &middot;&middot;<a href="/cgi-bin/npg/run/?id_run_status_dict=25&id_instrument_format=all&id_instrument=&manufacturer=Illumina"><span class="npg_nbsp ">qc on hold</span></a>&middot;&middot;
+  &middot;&middot;<a href="/cgi-bin/npg/run/?id_run_status_dict=17&id_instrument_format=all&id_instrument=&manufacturer=Illumina"><span class="npg_nbsp ">archival pending</span></a>&middot;&middot;
+  &middot;&middot;<a href="/cgi-bin/npg/run/?id_run_status_dict=18&id_instrument_format=all&id_instrument=&manufacturer=Illumina"><span class="npg_nbsp ">archival in progress</span></a>&middot;&middot;
+  &middot;&middot;<a href="/cgi-bin/npg/run/?id_run_status_dict=12&id_instrument_format=all&id_instrument=&manufacturer=Illumina"><span class="npg_nbsp ">run archived</span></a>&middot;&middot;
+  &middot;&middot;<a href="/cgi-bin/npg/run/?id_run_status_dict=20&id_instrument_format=all&id_instrument=&manufacturer=Illumina"><span class="npg_nbsp ">qc complete</span></a>&middot;&middot;
   </div>
 
 <div>
@@ -40,7 +40,7 @@
  <div class="smaller_font_85">
  <span class="medium_header ">Page: </span>
  
-  middot;<a class="active"  href="/cgi-bin/npg/run?id_run_status_dict=1&len=40&start=0&id_instrument_format=all&id_instrument=" id="pagination_1" >1</a>&middot;
+  middot;<a class="active"  href="/cgi-bin/npg/run?id_run_status_dict=1&len=40&start=0&id_instrument_format=all&id_instrument=&manufacturer=Illumina" id="pagination_1" >1</a>&middot;
  
  </div>
  </div>

--- a/t/data/rendered/run/runs_on_instrument.html
+++ b/t/data/rendered/run/runs_on_instrument.html
@@ -1,13 +1,13 @@
  <div class="roundborder">
  <div>
  <span class="page_title">Runs</span>
-&middot;&middot;<a target="runs_on_instrument" href="/cgi-bin/npg/run/?id_run_status_dict=all&id_instrument_format=all&id_instrument=3"  class="runs_active_selection">all</a>&middot;&middot;
-#  &middot;&middot;<a target="runs_on_instrument" href="/cgi-bin/npg/run/?id_run_status_dict=1&id_instrument_format=all&id_instrument=3">
+&middot;&middot;<a target="runs_on_instrument" href="/cgi-bin/npg/run/?id_run_status_dict=all&id_instrument_format=all&id_instrument=3&manufacturer=Illumina"  class="runs_active_selection">all</a>&middot;&middot;
+#  &middot;&middot;<a target="runs_on_instrument" href="/cgi-bin/npg/run/?id_run_status_dict=1&id_instrument_format=all&id_instrument=3&manufacturer=Illumina">
  </div>
  
  <div class="smaller_font_85">
  <span class="medium_header ">Page: </span>
- &middot;<a target="runs_on_instrument" class="active"  href="/cgi-bin/npg/run?id_run_status_dict=all&len=40&start=0&id_instrument_format=all&id_instrument=3" id="pagination_1" >1</a>&middot;
+ &middot;<a target="runs_on_instrument" class="active"  href="/cgi-bin/npg/run?id_run_status_dict=all&len=40&start=0&id_instrument_format=all&id_instrument=3&manufacturer=Illumina" id="pagination_1" >1</a>&middot;
  </div>
  </div>
  <table id="runs" class="sortable zebra">


### PR DESCRIPTION
Added a new optional parameter to methods
returning lists of runs and run count - the name of the manufacturer. If this name is undefined in the parameters hash, it defaults to 'Illumina'.

To avoid code repetition, consolidated queries for listing and counting runs, which wer epreviously
in six different places.

Simplified the logic of retrieving cached lists
and counts of runs vs computing new values.