### PR TITLE
Move elembio runs from archival_pending to run_archived

### DIFF
--- a/lib/Monitor/Elembio/Enum.pm
+++ b/lib/Monitor/Elembio/Enum.pm
@@ -34,6 +34,8 @@ our @EXPORT = qw(
   $RUN_PARAM_FILE
   $RUN_MANIFEST_FILE
   $RUN_STANDARD
+  $RUN_STATUS_ARCHIVAL_PENDING
+  $RUN_STATUS_ARCHIVED
   $RUN_STATUS_CANCELLED
   $RUN_STATUS_COMPLETE
   $RUN_STATUS_INPROGRESS
@@ -84,6 +86,8 @@ Readonly::Scalar our $RUN_MANIFEST_FILE => 'RunManifest.json';
 Readonly::Scalar our $RUN_STANDARD => 'Sequencing';
 Readonly::Scalar our $RUN_TYPE => 'RunType';
 Readonly::Scalar our $RUN_UPLOAD_FILE => 'RunUploaded.json';
+Readonly::Scalar our $RUN_STATUS_ARCHIVAL_PENDING => 'archival pending';
+Readonly::Scalar our $RUN_STATUS_ARCHIVED => 'run archived';
 Readonly::Scalar our $RUN_STATUS_CANCELLED => 'run cancelled';
 Readonly::Scalar our $RUN_STATUS_COMPLETE => 'run complete';
 Readonly::Scalar our $RUN_STATUS_INPROGRESS => 'run in progress';

--- a/t/36-elembio-monitor-runfolder.t
+++ b/t/36-elembio-monitor-runfolder.t
@@ -227,7 +227,7 @@ subtest 'test update on existing run actual cycle counter' => sub {
 };
 
 subtest 'test on existing run in progress and completed on disk' => sub {
-  plan tests => 15;
+  plan tests => 17;
 
   my $schema = t::dbic_util->new->test_schema();
   my $testdir = tempdir( CLEANUP => 1 );
@@ -276,6 +276,10 @@ subtest 'test on existing run in progress and completed on disk' => sub {
     'run complete date more recent than run in progress');
   lives_ok {$test->process_run_parameters();} 'process_run_parameters success on early return';
   is( $test->tracking_run()->current_run_status_description, 'run complete', 'current_run_status on complete after early return');
+
+  $test->tracking_run()->update_run_status('archival pending', 'pipeline');
+  lives_ok {$test->process_run_parameters();} 'process_run_parameters success when archival pending';
+  is( $test->tracking_run()->current_run_status_description, 'run archived', 'current_run_status on run archived after archival pending');
 };
 
 subtest 'test on not existing run but already completed on disk' => sub {


### PR DESCRIPTION
After QC actions, a run is set to `archival pending`. The staging monitor now can move runs from `archival pending` to `run archived`.