### PR TITLE
Add tracking runs with no run type

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 LIST OF CHANGES
 
+release 105.6.1 (2025-08-12)
+ - Bug fix - allow for registering old Elembio runs with no run type defined in RunParameters.json
+
 release 105.6.0 (2025-08-06)
  - Registration of 'cytoprofiling' runs in tracking DB
  - Simplification of Elembio parser: simplified compute of actual cycle count,

--- a/lib/Monitor/Elembio/RunFolder.pm
+++ b/lib/Monitor/Elembio/RunFolder.pm
@@ -309,7 +309,7 @@ sub _build_batch_id {
   my $self = shift;
   my $batch_id;
   # Cytoprofiling are not in production, so no batch_id for them
-  if ( $self->run_type ne $RUN_CYTOPROFILE ) {
+  if ( $self->run_type && ($self->run_type ne $RUN_CYTOPROFILE) ) {
     ($batch_id) = $self->_run_params_data()->{$RUN_NAME} =~ /\AB?(\d+)/smx;
     if (!$batch_id) {
       $self->logcarp("Run parameter batch_id: wrong format in $RUN_PARAM_FILE");
@@ -334,7 +334,7 @@ has q{expected_cycle_count}  => (
 sub _build_expected_cycle_count {
   my $self = shift;
   my @exp_cycles;
-  if ( $self->run_type eq $RUN_CYTOPROFILE ) {
+  if ( $self->run_type && ($self->run_type eq $RUN_CYTOPROFILE) ) {
     @exp_cycles =  map { $_->{$CYCLES} }
                    grep { $_->{'Type'} eq 'BarcodingBatch' }
                    @{$self->_run_params_data()->{'Batches'}};
@@ -367,8 +367,9 @@ sub _build_actual_cycle_count {
  
   my @cycle_files = ();
   if (-d $basecalls_dir) {
-    my $cycle_pattern = ($self->run_type eq $RUN_CYTOPROFILE) ?
-      $CYCLE_FILE_PATTERN_CYTO : $CYCLE_FILE_PATTERN;
+    my $cycle_pattern = ($self->run_type
+      && ($self->run_type eq $RUN_CYTOPROFILE)) ?
+        $CYCLE_FILE_PATTERN_CYTO : $CYCLE_FILE_PATTERN;
     my @files = glob catfile($basecalls_dir, '*.zip');
     foreach my $f ( @files ) {
       if (basename($f) =~ qr/$cycle_pattern/) {
@@ -513,7 +514,7 @@ sub _set_tags {
   if ($self->is_indexed) {
     push @tags, 'multiplex';
   }
-  if ($self->run_type eq $RUN_CYTOPROFILE) {
+  if ($self->run_type && ($self->run_type eq $RUN_CYTOPROFILE)) {
     push @tags, lc($self->run_type);
   }
 
@@ -607,7 +608,7 @@ Type of the run.
 
 =cut
 has q{run_type}     => (
-  isa           => q{Str},
+  isa           => q{Maybe[Str]},
   is            => q{ro},
   required      => 0,
   lazy_build    => 1,

--- a/t/36-elembio-monitor-runfolder.t
+++ b/t/36-elembio-monitor-runfolder.t
@@ -48,7 +48,7 @@ sub update_run_folder {
 use_ok('Monitor::Elembio::RunFolder');
 
 subtest 'test run parameters loader' => sub {
-  plan tests => 16;
+  plan tests => 17;
 
   my $schema = t::dbic_util->new->test_schema();
   my $testdir = tempdir( CLEANUP => 1 );
@@ -79,6 +79,7 @@ subtest 'test run parameters loader' => sub {
   is( $test->is_paired, 1, 'is_paired value correct' );
   is( $test->is_indexed, 1, 'is_indexed value correct' );
   is( $test->date_created->strftime('%Y-%m-%dT%H:%M:%S.%NZ'), $date, 'date_created value correct' );
+  is( $test->run_type, 'Sequencing', 'run_type value correct' );
   ok ( ! $test->find_run_db_record(), 'no run record in db' );
   isa_ok( $test->tracking_run(), 'npg_tracking::Schema::Result::Run',
           'Object returned by tracking_run method' );
@@ -86,7 +87,7 @@ subtest 'test run parameters loader' => sub {
 };
 
 subtest 'test on cytoprofiling run' => sub {
-  plan tests => 12;
+  plan tests => 13;
 
   my $schema = t::dbic_util->new->test_schema();
   my $testdir = tempdir( CLEANUP => 1 );
@@ -122,6 +123,7 @@ subtest 'test on cytoprofiling run' => sub {
   is( $test->actual_cycle_count, 66, 'actual cycle value correct' );
   is( $test->is_paired, 0, 'is_paired value correct' );
   is( $test->is_indexed, 0, 'is_indexed value correct' );
+  is( $test->run_type, 'Cytoprofiling', 'run_type value correct' );
   ok( ! $test->tracking_run()->current_run_status, 'current_run_status not set');
   ok( ! $test->tracking_run()->current_run_status_description, 'current_run_status_description undef');
   lives_ok {$test->process_run_parameters();} 'process_run_parameters succeeds';
@@ -131,7 +133,7 @@ subtest 'test on cytoprofiling run' => sub {
 };
 
 subtest 'test run parameters loader exceptions' => sub {
-  plan tests => 6;
+  plan tests => 7;
 
   my $schema = t::dbic_util->new->test_schema();
   my $testdir = tempdir( CLEANUP => 1 );
@@ -159,6 +161,7 @@ subtest 'test run parameters loader exceptions' => sub {
     'wrong lane count';
   ok( $test->date_created, 'missing date gives current date of RunParameters file' );
   is( $test->batch_id, undef, 'batch_id is undef');
+  is( $test->run_type, undef, 'run_type is undef' );
 };
 
 subtest 'test run parameters update on new run' => sub {

--- a/t/data/elembio_staging/AV244103/20250101_AV244103_NT1234567E/RunParameters.json
+++ b/t/data/elembio_staging/AV244103/20250101_AV244103_NT1234567E/RunParameters.json
@@ -1,6 +1,5 @@
 {
   "RunName": "NT1234567E",
-  "RunType": "Sequencing",
   "Side": "",
   "Date": "",
   "InstrumentName": "AV244103",


### PR DESCRIPTION
15 (of the oldest) runs from AVITI23 done in 2023 have no `RunType` field in the RunParameters.json and so they were never registered in tracking. With a recent change #910 these runs will be considered but skipped again by logging an error.
This fix will consider those runs through the normal workflow as in the `Sequencing` type and register them into tracking.