### PR TITLE
Isolate the RunParameters parser

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,9 @@
 LIST OF CHANGES
 
+unreleased
+ - Isolate the RunParameters.json parser from the Monitor::Elembio::RunFolder
+   into Monitor::Elembio::RunParametersParser
+
 release 105.6.1 (2025-08-12)
  - Bug fix - allow for registering old Elembio runs with no run type defined in RunParameters.json
 

--- a/Changes
+++ b/Changes
@@ -3,6 +3,9 @@ LIST OF CHANGES
 unreleased
  - Isolate the RunParameters.json parser from the Monitor::Elembio::RunFolder
    into Monitor::Elembio::RunParametersParser
+ - Refactor the elembio staging monitor to catch warnings from carp
+ - Remove verbose option and List::MoreUtils unused import from
+   the elembio staging monitor
 
 release 105.6.1 (2025-08-12)
  - Bug fix - allow for registering old Elembio runs with no run type defined in RunParameters.json

--- a/MANIFEST
+++ b/MANIFEST
@@ -124,6 +124,7 @@ htdocs/js/wtsi/sorttable.js
 htdocs/js/wtsi/zebra.js
 INSTALL
 lib/Monitor/Elembio/RunFolder.pm
+lib/Monitor/Elembio/RunParametersParser.pm
 lib/Monitor/Elembio/Staging.pm
 lib/Monitor/RunFolder.pm
 lib/Monitor/RunFolder/Staging.pm
@@ -402,6 +403,7 @@ t/34-monitor-runfolder.t
 t/34-monitor-staging.t
 t/35-monitor_one_runfolder.t
 t/36-elembio-monitor-runfolder.t
+t/36-elembio-monitor-runparametersparser.t
 t/36-elembio-monitor-staging.t
 t/40-st-lims-merge.t
 t/40-st-lims-mlwarehouse.t

--- a/bin/elembio_staging_area_monitor
+++ b/bin/elembio_staging_area_monitor
@@ -17,8 +17,9 @@ use Monitor::Elembio::RunFolder;
 
 our $VERSION = '0';
 
-# We rely on the daemon definition which redirects STDOUT to file
-# and so the logger below will print messages to STDOUT by default.
+# We rely on the daemon definition which redirects both STDOUT and STDERR
+# to file with -o option. The following configuration prints logs
+# to STDERR by default.
 my $log_config = << 'LOGCONF'
 log4perl.logger = INFO, A1
 
@@ -39,6 +40,40 @@ Readonly::Scalar my $DRY_RUN => $ENV{'dev'} && ($ENV{'dev'} ne 'live');
 
 local $OUTPUT_AUTOFLUSH = 1;
 
+my $help;
+my @staging_areas;
+my $log4perl_config;
+my $debug;
+my $verbose;
+GetOptions (
+  'help'                        => sub {
+    pod2usage(-verbose => 2, -exitval => 0);
+  },
+  'staging_area|staging-area=s' => \@staging_areas,
+  'logconf=s'                   => \$log4perl_config,
+  'debug'                       => \$debug,
+  'verbose'                     => \$verbose,
+);
+
+if ($log4perl_config) {
+  Log::Log4perl::init($log4perl_config);
+} else {
+  if ($debug and not $verbose) {
+    Log::Log4perl->easy_init({layout => '%d %-5p %c - %m%n',
+                              level  => $DEBUG,
+                              utf8   => 1});
+  }
+  else {
+    Log::Log4perl::init(\$log_config);
+  }
+}
+my $log = Log::Log4perl->get_logger('main');
+
+local $SIG{__WARN__} = sub {
+  my $message = shift;
+  $log->warn($message);
+};
+
 main();
 
 ###########################################################
@@ -46,36 +81,6 @@ main();
 ###########################################################
 
 sub main {
-  my $help;
-  my @staging_areas;
-  my $log4perl_config;
-  my $debug;
-  my $verbose;
-  GetOptions (
-    'help'                        => sub {
-      pod2usage(-verbose => 2, -exitval => 0);
-    },
-    'staging_area|staging-area=s' => \@staging_areas,
-    'logconf=s'                   => \$log4perl_config,
-    'debug'                       => \$debug,
-    'verbose'                     => \$verbose,
-  );
-
-  if ($log4perl_config) {
-    Log::Log4perl::init($log4perl_config);
-  } else {
-    if ($debug and not $verbose) {
-      Log::Log4perl->easy_init({layout => '%d %-5p %c - %m%n',
-                                level  => $DEBUG,
-                                utf8   => 1});
-    }
-    else {
-      Log::Log4perl::init(\$log_config);
-    }
-  }
-  my $log = Log::Log4perl->get_logger('main');
-  $log->level($ALL);
-
   if (! @staging_areas) {
     $log->fatal("ERROR: --staging_area/--staging-area argument is required");
     exit 1;

--- a/bin/elembio_staging_area_monitor
+++ b/bin/elembio_staging_area_monitor
@@ -7,7 +7,6 @@ use lib ( -d "$Bin/../lib/perl5" ? "$Bin/../lib/perl5" : "$Bin/../lib" );
 use English qw(-no_match_vars);
 use Readonly;
 use Try::Tiny;
-use List::MoreUtils qw(any);
 use Log::Log4perl qw[:levels];
 use Pod::Usage;
 use Getopt::Long;
@@ -44,7 +43,6 @@ my $help;
 my @staging_areas;
 my $log4perl_config;
 my $debug;
-my $verbose;
 GetOptions (
   'help'                        => sub {
     pod2usage(-verbose => 2, -exitval => 0);
@@ -52,13 +50,12 @@ GetOptions (
   'staging_area|staging-area=s' => \@staging_areas,
   'logconf=s'                   => \$log4perl_config,
   'debug'                       => \$debug,
-  'verbose'                     => \$verbose,
 );
 
 if ($log4perl_config) {
   Log::Log4perl::init($log4perl_config);
 } else {
-  if ($debug and not $verbose) {
+  if ($debug) {
     Log::Log4perl->easy_init({layout => '%d %-5p %c - %m%n',
                               level  => $DEBUG,
                               utf8   => 1});
@@ -137,7 +134,7 @@ elembio_staging_area_monitor
 =head1 SYNOPSIS
 
 elembio_staging_area_monitor --staging-area <path>
-  [--debug] [--verbose]
+  [--debug] [--logconf]
 
   Options:
     --staging-area  The staging area folder. The following pattern will
@@ -147,13 +144,10 @@ elembio_staging_area_monitor --staging-area <path>
 
     --logconf       A file containing log4perl configuration with log
                       dispatchers. It may include one or more dispatchers
-                      to log messages to different resources.
-                      Highest priority among debug and verbose.
+                      to log messages to different resources. Optional.
+                      Higher priority than debug.
 
     --debug         Enable debug level logging. Optional.
-
-    --verbose       Print messages from the script and used modules 
-                      while processing. Optional. Higher priority than debug.
 
 =head1 DESCRIPTION
 

--- a/bin/elembio_staging_area_monitor
+++ b/bin/elembio_staging_area_monitor
@@ -17,6 +17,8 @@ use Monitor::Elembio::RunFolder;
 
 our $VERSION = '0';
 
+# We rely on the daemon definition which redirects STDOUT to file
+# and so the logger below will print messages to STDOUT by default.
 my $log_config = << 'LOGCONF'
 log4perl.logger = INFO, A1
 

--- a/lib/Monitor/Elembio/RunParametersParser.pm
+++ b/lib/Monitor/Elembio/RunParametersParser.pm
@@ -1,0 +1,423 @@
+package Monitor::Elembio::RunParametersParser;
+
+use Moose;
+use Carp;
+use Readonly;
+use JSON;
+use File::Spec::Functions qw( catfile );
+use DateTime;
+use List::Util qw( sum );
+use DateTime::Format::Strptime;
+use Perl6::Slurp;
+use Try::Tiny;
+
+use npg_tracking::util::types;
+
+with qw[
+  WTSI::DNAP::Utilities::Loggable
+];
+
+our $VERSION = '0';
+
+# Property Enums
+Readonly::Scalar my $CONSUMABLES => 'Consumables';
+Readonly::Scalar my $CYCLES => 'Cycles';
+Readonly::Scalar my $CYCLES_I1 => 'I1';
+Readonly::Scalar my $CYCLES_R2 => 'R2';
+Readonly::Scalar my $DATE => 'Date';
+Readonly::Scalar my $FLOWCELL => 'Flowcell';
+Readonly::Scalar my $FOLDER_NAME => 'RunFolderName';
+Readonly::Scalar my $INSTRUMENT_NAME => 'InstrumentName';
+Readonly::Scalar my $LANES => 'AnalysisLanes';
+Readonly::Scalar my $RUN_NAME => 'RunName';
+Readonly::Scalar my $SERIAL_NUMBER => 'SerialNumber';
+Readonly::Scalar my $SIDE => 'Side';
+Readonly::Scalar my $TIME_PATTERN => '%Y-%m-%dT%H:%M:%S.%NZ'; # 2023-12-19T13:31:17.461926614Z
+
+# Run Enums
+Readonly::Scalar my $RUN_CYTOPROFILE => 'Cytoprofiling';
+Readonly::Scalar my $RUN_PARAM_FILE => 'RunParameters.json';
+Readonly::Scalar my $RUN_TYPE => 'RunType';
+
+=head1 NAME
+
+Monitor::Elembio::RunParametersParser
+
+=head1 VERSION
+
+=head1 SYNOPSIS
+
+C<<use Monitor::Elembio::RunParametersParser;
+   my $run_folder = Monitor::Elembio::RunParametersParser->new(
+     runfolder_path      => $run_folder);>>
+
+=head1 DESCRIPTION
+
+Elembio parser for RunParameters.json file
+
+=head1 SUBROUTINES/METHODS
+
+=head2 BUILD
+
+An extension for the constructor method. Checks that either
+runfolder_path or runparams_path are specified.
+
+=cut
+
+sub BUILD {
+  my $self = shift;
+  $self->has_runfolder_path || $self->has_runparams_path
+    || $self->logcroak();
+}
+
+=head2 runfolder_path
+
+Path of the run folder.
+
+=cut
+has q{runfolder_path} => (
+  isa           => q{Str},
+  is            => q{ro},
+  predicate     => q{has_runfolder_path},
+  required      => 0,
+);
+
+=head2 runparams_path
+
+Path of the RunParameters.json file.
+
+=cut
+has q{runparams_path} => (
+  isa           => q{Str},
+  is            => q{ro},
+  predicate     => q{has_runparams_path},
+  required      => 0,
+);
+
+=head2 flowcell_id
+
+A string containing the flowcell ID used for the sequencing.
+It is retrieved from RunParameters.json file.
+
+=cut
+has q{flowcell_id}  => (
+  isa             => q{Str},
+  is              => q{ro},
+  required        => 0,
+  lazy_build      => 1,
+);
+sub _build_flowcell_id {
+  my $self = shift;
+  my $flowcell_id = $self->_run_params_data()
+    ->{$CONSUMABLES}->{$FLOWCELL}->{$SERIAL_NUMBER};
+  if (! $flowcell_id) {
+    $self->logcroak('Empty value in flowcell_id');
+  }
+  return $flowcell_id;
+}
+
+=head2 folder_name
+
+A string containing a time stamp, flowcell_id and run name
+that define a run. It is retrieved from RunParameters.json file.
+
+=cut
+has q{folder_name}    => (
+  isa               => q{Str},
+  is                => q{ro},
+  required          => 0,
+  lazy_build        => 1,
+);
+sub _build_folder_name {
+  my $self = shift;
+  my $folder_name = $self->_run_params_data()->{$FOLDER_NAME};
+  if (! $folder_name) {
+    $self->logcroak('Empty value in folder_name');
+  }
+  return $folder_name;
+}
+
+=head2 instrument_name
+
+A unique (external) name assigned to the instrument
+and retrieved from RunParameters.json file.
+
+=cut
+has q{instrument_name}  => (
+  isa               => q{Str},
+  is                => q{ro},
+  required          => 0,
+  lazy_build        => 1,
+);
+sub _build_instrument_name {
+  my $self = shift;
+  return $self->_run_params_data()->{$INSTRUMENT_NAME};
+}
+
+=head2 instrument_side
+
+The instrument side where the sequencing is performed.
+It is retrieved from RunParameters.json file.
+
+=cut
+has q{instrument_side}     => (
+  isa           => q{Str},
+  is            => q{ro},
+  required      => 0,
+  lazy_build    => 1,
+);
+sub _build_instrument_side {
+  my $self = shift;
+  my ($side) = $self->_run_params_data()->{$SIDE} =~ /Side(A|B)/smx;
+  if (!$side) {
+    $self->logcroak("Run parameter $SIDE: wrong format in $RUN_PARAM_FILE");
+  }
+  return $side;
+}
+
+=head2 batch_id
+
+The sequencing batch ID. It is retrieved from the run name
+of the RunParameters.json file.
+
+Not being able to extract batch ID from the run name is not 
+an error. Walk-up runs are not tracked through LIMS.
+
+=cut
+has q{batch_id}     => (
+  isa           => q{Maybe[NpgTrackingPositiveInt]},
+  is            => q{ro},
+  required      => 0,
+  lazy_build    => 1,
+);
+sub _build_batch_id {
+  my $self = shift;
+  my $batch_id;
+  # Cytoprofiling are not in production, so no batch_id for them
+  if ( $self->run_type && ($self->run_type ne $RUN_CYTOPROFILE) ) {
+    ($batch_id) = $self->_run_params_data()->{$RUN_NAME} =~ /\AB?(\d+)/smx;
+    if (!$batch_id) {
+      $self->logcarp("Run parameter batch_id: wrong format in $RUN_PARAM_FILE");
+    }
+  }
+  return $batch_id;
+}
+
+=head2 expected_cycle_count
+
+The number of sequencing cycles that the instrument
+is expected to complete. It is retrieved from
+RunParameters.json file.
+
+=cut
+has q{expected_cycle_count}  => (
+  isa               => q{Int},
+  is                => q{ro},
+  required          => 0,
+  lazy_build        => 1,
+);
+sub _build_expected_cycle_count {
+  my $self = shift;
+  my @exp_cycles;
+  if ( $self->run_type && ($self->run_type eq $RUN_CYTOPROFILE) ) {
+    @exp_cycles =  map { $_->{$CYCLES} }
+                   grep { $_->{'Type'} eq 'BarcodingBatch' }
+                   @{$self->_run_params_data()->{'Batches'}};
+  } else {
+    @exp_cycles = values %{$self->_run_params_data()->{$CYCLES}};
+  }
+  return sum @exp_cycles;
+}
+
+=head2 lane_count
+
+The number of lanes that are used on one side.
+It is retrieved from RunParameters.json file.
+
+=cut
+has q{lane_count}  => (
+  isa               => q{Int},
+  is                => q{ro},
+  required          => 0,
+  lazy_build        => 1,
+);
+sub _build_lane_count {
+  my $self = shift;
+  my @lanes = split /\+/, $self->_run_params_data()->{$LANES};
+  if (! @lanes) {
+    $self->logcroak("Run parameter $LANES: No lane found");
+  }
+  return scalar @lanes;
+}
+
+=head2 date_created
+
+The date when the run was created.
+By default, it is retrieved from the RunParameters.json.
+If not present in the file, the time stamp of the file is choosen.
+
+=cut
+has q{date_created} => (
+  isa               => q{DateTime},
+  is                => q{ro},
+  required          => 0,
+  lazy_build        => 1,
+);
+sub _build_date_created {
+  my $self = shift;
+  my $file_path = catfile($self->runfolder_path, $RUN_PARAM_FILE);
+  if (! exists $self->_run_params_data()->{$DATE} or ! $self->_run_params_data()->{$DATE}) {
+    $self->logcarp("Run parameter $DATE: No value in $RUN_PARAM_FILE");
+    return DateTime->from_epoch(epoch => (stat  $file_path)[9]);
+  } else {
+    my $date = $self->_run_params_data()->{$DATE};
+    try {
+      return DateTime::Format::Strptime->new(
+        pattern=>$TIME_PATTERN,
+        strict=>1,
+        on_error=>q[croak]
+      )->parse_datetime($date);
+    } catch {
+      $self->logcarp("Run parameter $DATE: failed to parse $date");
+      return DateTime->from_epoch(epoch => (stat  $file_path)[9]);
+    };
+  }
+}
+
+=head2 is_paired
+
+If paired run (the run has a reverse read) return 1, otherwise 0.
+
+=cut
+has q{is_paired} => (
+  isa         => q{Bool},
+  is          => q{ro},
+  required    => 0,
+  lazy_build  => 1,
+);
+sub _build_is_paired {
+  my $self = shift;
+  my $cycles = $self->_run_params_data()->{$CYCLES};
+  if ( exists $cycles->{$CYCLES_R2} and int($cycles->{$CYCLES_R2}) > 0 ) {
+    return 1;
+  }
+  return 0;
+}
+
+=head2 is_indexed
+
+If the run has at least one index read return 1, otherwise 0.
+
+=cut
+has q{is_indexed} => (
+  isa         => q{Bool},
+  is          => q{ro},
+  required    => 0,
+  lazy_build  => 1,
+);
+sub _build_is_indexed {
+  my $self = shift;
+  my $cycles = $self->_run_params_data()->{$CYCLES};
+  if ( exists $cycles->{$CYCLES_I1} and int($cycles->{$CYCLES_I1}) > 0 ) {
+    return 1;
+  }
+  return 0;
+}
+
+#####
+# Hash reference that represents the JSON file content of RunParameters.json.
+has q{_run_params_data} => (
+  isa               => q{HashRef},
+  is                => q{ro},
+  required          => 0,
+  init_arg          => undef,
+  lazy_build        => 1,
+);
+sub _build__run_params_data {
+  my $self = shift;
+  my $run_parameters_file = catfile($self->runfolder_path, $RUN_PARAM_FILE);
+  return decode_json(slurp $run_parameters_file);
+}
+
+=head2 run_type
+
+Type of the run.
+
+=cut
+has q{run_type}     => (
+  isa           => q{Maybe[Str]},
+  is            => q{ro},
+  required      => 0,
+  lazy_build    => 1,
+);
+sub _build_run_type {
+  my $self = shift;
+  return $self->_run_params_data()->{$RUN_TYPE};
+}
+
+1;
+
+__END__
+
+=head1 DIAGNOSTICS
+
+=head1 CONFIGURATION AND ENVIRONMENT
+
+=head1 DEPENDENCIES
+
+=over
+
+=item Moose
+
+=item Carp
+
+=item Readonly
+
+=item JSON
+
+=item File::Spec::Functions
+
+=item DateTime
+
+=item List::Util
+
+=item DateTime::Format::Strptime
+
+=item Perl6::Slurp
+
+=item Try::Tiny
+
+=item npg_tracking::util::types
+
+=back
+
+=head1 INCOMPATIBILITIES
+
+=head1 BUGS AND LIMITATIONS
+
+=head1 AUTHOR
+
+=over
+
+=item Marco M. Mosca
+
+=back
+
+=head1 LICENSE AND COPYRIGHT
+
+Copyright (C) 2025 Genome Research Ltd.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+=cut

--- a/t/36-elembio-monitor-runfolder.t
+++ b/t/36-elembio-monitor-runfolder.t
@@ -3,7 +3,7 @@ use warnings;
 use File::Basename;
 use File::Copy;
 use File::Copy::Recursive qw( dircopy );
-use Test::More tests => 10;
+use Test::More tests => 9;
 use Test::Exception;
 use Test::Warn;
 use File::Temp qw/ tempdir /;
@@ -130,38 +130,6 @@ subtest 'test on cytoprofiling run' => sub {
   ok( $test->tracking_run()->current_run_status, 'current_run_status set');
   is( $test->tracking_run()->current_run_status_description, 'run in progress', 'current_run_status_description correct');
   ok( $test->tracking_run()->is_tag_set('cytoprofiling'), 'cytoprofiling tag is set');
-};
-
-subtest 'test run parameters loader exceptions' => sub {
-  plan tests => 7;
-
-  my $schema = t::dbic_util->new->test_schema();
-  my $testdir = tempdir( CLEANUP => 1 );
-  my $instrument_folder = 'AV244103';
-  my $run_folder_name = '20250101_AV244103_NT1234567E';
-  my $data_folder = catdir('t/data/elembio_staging', $instrument_folder, $run_folder_name);
-  my $runfolder_path = catdir($testdir, $instrument_folder, $run_folder_name);
-  dircopy($data_folder, $runfolder_path) or die "cannot copy test directory $!";
-
-  update_run_folder($runfolder_path);
-
-  my $test = Monitor::Elembio::RunFolder->new( runfolder_path      => $runfolder_path,
-                                                npg_tracking_schema => $schema);
-  throws_ok{ $test->folder_name }
-    qr/Empty[ ]value[ ]in[ ]folder_name/msx,
-    'folder name empty';
-  throws_ok{ $test->flowcell_id }
-    qr/Empty[ ]value[ ]in[ ]flowcell_id/msx,
-    'flowcell ID empty';
-  throws_ok { $test->instrument_side }
-    qr/Run[ ]parameter[ ]Side:[ ]wrong[ ]format[ ]in[ ]RunParameters[.]json/msx,
-    'wrong side value';
-  throws_ok { $test->lane_count }
-    qr/Run[ ]parameter[ ]AnalysisLanes:[ ]No[ ]lane[ ]found/msx,
-    'wrong lane count';
-  ok( $test->date_created, 'missing date gives current date of RunParameters file' );
-  is( $test->batch_id, undef, 'batch_id is undef');
-  is( $test->run_type, undef, 'run_type is undef' );
 };
 
 subtest 'test run parameters update on new run' => sub {

--- a/t/36-elembio-monitor-runparametersparser.t
+++ b/t/36-elembio-monitor-runparametersparser.t
@@ -1,0 +1,96 @@
+use strict;
+use warnings;
+use File::Copy;
+use File::Copy::Recursive qw( dircopy );
+use Test::More tests => 4;
+use Test::Exception;
+use Test::Warn;
+use File::Temp qw/ tempdir /;
+use File::Spec::Functions qw( catdir );
+
+use t::dbic_util;
+
+use_ok('Monitor::Elembio::RunParametersParser');
+
+subtest 'test run parameters loader' => sub {
+  plan tests => 11;
+
+  my $schema = t::dbic_util->new->test_schema();
+  my $testdir = tempdir( CLEANUP => 1 );
+  my $instrument_folder = 'AV244103';
+  my $run_name = '1234';
+  my $run_folder_name = "20250417_${instrument_folder}_${run_name}";
+  my $flowcell_id = '2441447657';
+  my $date = '2025-04-17T13:57:00.861333784Z';
+  my $data_folder = catdir('t/data/elembio_staging', $instrument_folder, $run_folder_name);
+  my $runfolder_path = catdir($testdir, $instrument_folder, $run_folder_name);
+  dircopy($data_folder, $runfolder_path) or die "cannot copy test directory $!";
+
+  my $test = Monitor::Elembio::RunParametersParser->new(
+    runfolder_path => $runfolder_path);
+  isa_ok( $test, 'Monitor::Elembio::RunParametersParser' );
+  is( $test->folder_name, $run_folder_name, 'run_folder value correct' );
+  is( $test->flowcell_id, $flowcell_id, 'flowcell_id value correct' );
+  is( $test->batch_id, 1234, 'batch_id value correct' );
+  is( $test->instrument_side, 'A', 'side value correct' );
+  is( $test->expected_cycle_count, 210, 'expected cycle value correct' );
+  is( $test->lane_count, 2, 'lanes number value correct' );
+  is( $test->is_paired, 1, 'is_paired value correct' );
+  is( $test->is_indexed, 1, 'is_indexed value correct' );
+  is( $test->date_created->strftime('%Y-%m-%dT%H:%M:%S.%NZ'), $date, 'date_created value correct' );
+  is( $test->run_type, 'Sequencing', 'run_type value correct' );
+};
+
+subtest 'test on cytoprofiling run' => sub {
+  plan tests => 6;
+
+  my $schema = t::dbic_util->new->test_schema();
+  my $testdir = tempdir( CLEANUP => 1 );
+  my $instrument_folder = 'AV244103';
+  my $run_name = '2345';
+  my $run_folder_name = "20250415_${instrument_folder}_${run_name}";
+  my $data_folder = catdir('t/data/elembio_staging', $instrument_folder, $run_folder_name);
+  my $runfolder_path = catdir($testdir, $instrument_folder, $run_folder_name);
+  dircopy($data_folder, $runfolder_path) or die "cannot copy test directory $!";
+
+  my $test = Monitor::Elembio::RunParametersParser->new(
+    runfolder_path => $runfolder_path);
+  isa_ok( $test, 'Monitor::Elembio::RunParametersParser' );
+  is( $test->batch_id, undef, 'batch_id value undef' );
+  is( $test->expected_cycle_count, 77, 'expected cycle value correct' );
+  is( $test->is_paired, 0, 'is_paired value correct' );
+  is( $test->is_indexed, 0, 'is_indexed value correct' );
+  is( $test->run_type, 'Cytoprofiling', 'run_type value correct' );
+};
+
+subtest 'test run parameters loader exceptions' => sub {
+  plan tests => 7;
+
+  my $schema = t::dbic_util->new->test_schema();
+  my $testdir = tempdir( CLEANUP => 1 );
+  my $instrument_folder = 'AV244103';
+  my $run_folder_name = '20250101_AV244103_NT1234567E';
+  my $data_folder = catdir('t/data/elembio_staging', $instrument_folder, $run_folder_name);
+  my $runfolder_path = catdir($testdir, $instrument_folder, $run_folder_name);
+  dircopy($data_folder, $runfolder_path) or die "cannot copy test directory $!";
+
+  my $test = Monitor::Elembio::RunParametersParser->new(
+    runfolder_path => $runfolder_path);
+  throws_ok{ $test->folder_name }
+    qr/Empty[ ]value[ ]in[ ]folder_name/msx,
+    'folder name empty';
+  throws_ok{ $test->flowcell_id }
+    qr/Empty[ ]value[ ]in[ ]flowcell_id/msx,
+    'flowcell ID empty';
+  throws_ok { $test->instrument_side }
+    qr/Run[ ]parameter[ ]Side:[ ]wrong[ ]format[ ]in[ ]RunParameters[.]json/msx,
+    'wrong side value';
+  throws_ok { $test->lane_count }
+    qr/Run[ ]parameter[ ]AnalysisLanes:[ ]No[ ]lane[ ]found/msx,
+    'wrong lane count';
+  ok( $test->date_created, 'missing date gives current date of RunParameters file' );
+  is( $test->batch_id, undef, 'batch_id is undef');
+  is( $test->run_type, undef, 'run_type is undef' );
+};
+
+1;


### PR DESCRIPTION
- Attributes that access RunParameters.json are now moved into Monitor::Elembio::RunParametersParser
- Monitor::Elembio::RunFolder contains functions that connect to the DB schema (`tracking_run`) and/or deal with dynamic properties of the run folder such as the `actual_cycle_count`.
- Tests for RunFolder are the same as before except for the test batch (7 subtests) that deals with exception (now moved)
- Essential tests for RunParameters class (RunParameters.json parser) are handled in a separate test file.