### PR TITLE
Ensured consistency in handling paths

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,7 +2,13 @@ LIST OF CHANGES
 
  - Updated instrument image generation so that the rendered image for Elembio
    instruments is correct.
- - Added run_name attribute to Monitor::Elembio::RunParametersParser
+ - Updated Monitor::Elembio::RunParametersParser :
+   - added run_name attribute,
+   - changed the attribute type of both runparams_path and runfolder_path so
+     that the existence of the relevant file or directory is performed,
+   - added builder methods for runparams_path and runfolder_path attributes,
+   - ensured that runfolder_path attribute is used when a path of the
+     RunParameters.json file is needed.
 
 release 105.7.0 (2025-08-18)
  - Isolate the RunParameters.json parser from the Monitor::Elembio::RunFolder

--- a/t/36-elembio-monitor-runparametersparser.t
+++ b/t/36-elembio-monitor-runparametersparser.t
@@ -5,11 +5,12 @@ use File::Spec::Functions qw( catdir );
 use File::Temp qw( tempdir );
 use Test::More tests => 4;
 use Test::Exception;
+use Test::Warn;
 
 use_ok('Monitor::Elembio::RunParametersParser');
 
 subtest 'test run parameters loader' => sub {
-  plan tests => 12;
+  plan tests => 16;
 
   my $testdir = tempdir( CLEANUP => 1 );
   my $instrument_folder = 'AV244103';
@@ -24,6 +25,8 @@ subtest 'test run parameters loader' => sub {
   my $test = Monitor::Elembio::RunParametersParser->new(
     runfolder_path => $runfolder_path);
   isa_ok( $test, 'Monitor::Elembio::RunParametersParser' );
+  is( $test->runparams_path, "$runfolder_path/RunParameters.json",
+    'runparams_path is built correctly');
   is( $test->folder_name, $run_folder_name, 'run_folder value correct' );
   is( $test->flowcell_id, $flowcell_id, 'flowcell_id value correct' );
   is( $test->run_name, '1234', 'run name is correct');
@@ -33,8 +36,16 @@ subtest 'test run parameters loader' => sub {
   is( $test->lane_count, 2, 'lanes number value correct' );
   is( $test->is_paired, 1, 'is_paired value correct' );
   is( $test->is_indexed, 1, 'is_indexed value correct' );
-  is( $test->date_created->strftime('%Y-%m-%dT%H:%M:%S.%NZ'), $date, 'date_created value correct' );
+  is( $test->date_created->strftime('%Y-%m-%dT%H:%M:%S.%NZ'), $date,
+    'date_created value correct' );
   is( $test->run_type, 'Sequencing', 'run_type value correct' );
+  
+  $test = Monitor::Elembio::RunParametersParser->new(
+    runparams_path => "$runfolder_path/RunParameters.json");
+  is( $test->runfolder_path, $runfolder_path,
+    'run folder path is inferred correctly');
+  is( $test->folder_name, $run_folder_name, 'run_folder value correct' );
+  is( $test->flowcell_id, $flowcell_id, 'flowcell_id value correct' );
 };
 
 subtest 'test on cytoprofiling run' => sub {
@@ -60,8 +71,25 @@ subtest 'test on cytoprofiling run' => sub {
 };
 
 subtest 'test run parameters loader exceptions' => sub {
-  plan tests => 7;
+  plan tests => 13;
 
+  throws_ok { Monitor::Elembio::RunParametersParser->new() }
+    qr/runfolder_path or runparams_path must be specified/,
+    'error if neither runfolder_path or runparams_path is set via the constructor';
+  throws_ok { Monitor::Elembio::RunParametersParser
+    ->new(runfolder_path => '/unknown')
+  } qr/Validation failed for 'NpgTrackingDirectory' with value \/unknown/,
+    'error when non-exising runfolder path is given';
+  throws_ok { Monitor::Elembio::RunParametersParser
+    ->new(runparams_path => 't/RunParameters.json')
+  } qr/Validation failed for 'NpgTrackingReadableFile' with value t\/RunParameters.json/,
+    'error when non-exising RunParameters.json is given';
+
+  my $test = Monitor::Elembio::RunParametersParser->new(runfolder_path => 't');
+  throws_ok { $test->runparams_path }
+    qr/Validation failed for 'NpgTrackingReadableFile' with value t\/RunParameters.json/,
+    'error building runparams_path attribute - RunParameters.json does not exist';
+  
   my $testdir = tempdir( CLEANUP => 1 );
   my $instrument_folder = 'AV244103';
   my $run_folder_name = '20250101_AV244103_NT1234567E';
@@ -69,7 +97,14 @@ subtest 'test run parameters loader exceptions' => sub {
   my $runfolder_path = catdir($testdir, $instrument_folder, $run_folder_name);
   dircopy($data_folder, $runfolder_path) or die "cannot copy test directory $!";
 
-  my $test = Monitor::Elembio::RunParametersParser->new(
+  my $file = "$runfolder_path/RunParameters.json";
+  ok( -e $file, "$file file exists");
+  my $time = DateTime->new(
+    year => 2025,month => 1,day => 29,hour => 13,minute => 30,second => 0
+  )->epoch;
+  utime $time, $time, $file; # set the timestamp
+
+  $test = Monitor::Elembio::RunParametersParser->new(
     runfolder_path => $runfolder_path);
   throws_ok{ $test->folder_name }
     qr/Empty[ ]value[ ]in[ ]folder_name/msx,
@@ -83,7 +118,12 @@ subtest 'test run parameters loader exceptions' => sub {
   throws_ok { $test->lane_count }
     qr/Run[ ]parameter[ ]AnalysisLanes:[ ]No[ ]lane[ ]found/msx,
     'wrong lane count';
-  ok( $test->date_created, 'missing date gives current date of RunParameters file' );
+  my $date;
+  warning_like { $date = $test->date_created }
+    qr/Run parameter Date: No value in RunParameters.json/,
+    'warning about missing run creation date';
+  is( $date->strftime('%Y-%m-%dT%H:%M:%S'), '2025-01-29T13:30:00',
+    'missing date has a fallback of RunParameters.json file creation' );
   is( $test->batch_id, undef, 'batch_id is undef');
   is( $test->run_type, undef, 'run_type is undef' );
 };


### PR DESCRIPTION
Ensured consistency in handling paths in
Monitor::Elembio::RunParametersParser

Changed the attribute type of both runparams_path and runfolder_path so that the existence of the relevant file or directory is performed.

Added builder methods for runparams_path and runfolder_path attributes.

Ensured that runfolder_path attribute is used when a path of the RunParameters.json file is needed.