### PR TITLE
Update the staging paths for Ultimagen instruments

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 LIST OF CHANGES
 
+ - Fix the staging area path for Ultimagen 'UG 200' instrument in the daemon.
+   The external name 'U10' is now updated to 'U010'.
+
 release 107.1.0 (2026-05-11)
  - Events are created for all run statuses. The customers are interested only
    in some of them. Prior to release 106.2.0 all events were ticked off as

--- a/Changes
+++ b/Changes
@@ -2,6 +2,8 @@ LIST OF CHANGES
 
  - Fix the staging area path for Ultimagen 'UG 200' instrument in the daemon.
    The external name 'U10' is now updated to 'U010'.
+ - Remove 'Runs' subfolder when globbing for Ultimagen run folders and the
+   the old 'staging/Runs' folder used for 'V125' from the daemon.
 
 release 107.1.0 (2026-05-11)
  - Events are created for all run statuses. The customers are interested only

--- a/lib/Monitor/Ultimagen/Staging.pm
+++ b/lib/Monitor/Ultimagen/Staging.pm
@@ -12,7 +12,7 @@ use Exporter;
 our @ISA= qw( Exporter );
 our @EXPORT = qw( find_run_folders );
 
-Readonly::Scalar my $RUN_LIBRARYINFO_GLOB => 'Runs/**/*_LibraryInfo.xml';
+Readonly::Scalar my $RUN_LIBRARYINFO_GLOB => '**/*_LibraryInfo.xml';
 
 our $VERSION = '0';
 

--- a/lib/npg_tracking/daemon/ultimagenstaging.pm
+++ b/lib/npg_tracking/daemon/ultimagenstaging.pm
@@ -11,7 +11,7 @@ our $VERSION = '0';
 Readonly::Scalar my $SCRIPT_NAME => q[ultimagen_staging_area_monitor];
 Readonly::Array  my @STAGING_AREAS =>
   map { '/lustre/scratch120/openstack/default/ultima/' . $_ }
-  qw( staging staging/V125 staging/U010 );
+  qw( staging/V125 staging/U010 );
 
 override 'daemon_name'  => sub { return $SCRIPT_NAME; };
 override 'command'      => sub {

--- a/lib/npg_tracking/daemon/ultimagenstaging.pm
+++ b/lib/npg_tracking/daemon/ultimagenstaging.pm
@@ -11,7 +11,7 @@ our $VERSION = '0';
 Readonly::Scalar my $SCRIPT_NAME => q[ultimagen_staging_area_monitor];
 Readonly::Array  my @STAGING_AREAS =>
   map { '/lustre/scratch120/openstack/default/ultima/' . $_ }
-  qw( staging staging/V125 staging/U10 );
+  qw( staging staging/V125 staging/U010 );
 
 override 'daemon_name'  => sub { return $SCRIPT_NAME; };
 override 'command'      => sub {

--- a/t/37-ultimagen-monitor-staging.t
+++ b/t/37-ultimagen-monitor-staging.t
@@ -17,10 +17,8 @@ subtest 'test ultimagen staging monitor find_run_folders' => sub {
   plan tests => 3;
 
   my $testdir = tempdir( CLEANUP => 1 );
-  my $allruns_folder = 'Runs';
-  my $data_folder = catdir('t/data/ultimagen_staging', $allruns_folder);
-  my $test_allruns_folder = catdir($testdir, $allruns_folder);
-  dircopy($data_folder, $test_allruns_folder) or die "cannot copy test directory $!";
+  my $data_folder = 't/data/ultimagen_staging/Runs';
+  dircopy($data_folder, $testdir) or die "cannot copy test directory $!";
   throws_ok { find_run_folders() }
             qr/Top[ ]level[ ]staging[ ]path[ ]required/msx,
             'Require path argument';


### PR DESCRIPTION
- The external name that we use for `UG 200` instrument has a mismatch between the label attached on the instrument and the cloud records. Ultima people confirmed that the cloud records are the correct ones. Update the external name from `U10` to `U010`.

- Remove `Runs` subfolder when globbing for Ultimagen run folders since the instruments will write to `staging/V125` and `staging/U010` by the new settings.

- Remove the old `staging/Runs` folder used for 'V125' from the daemon.

Merge when the staging area is updated on the instrument