### PR TITLE
Add UG200 monitor support

### DIFF
--- a/Changes
+++ b/Changes
@@ -5,6 +5,8 @@ LIST OF CHANGES
  - Remove 'Runs' subfolder when globbing for Ultimagen run folders and the
    the old 'staging/Runs' folder used for 'V125' from the daemon.
  - Add a new instrument, instrument format and designation records for 'UG 200'.
+ - Add tracking monitor support for new Ultimagen instruments by parsing out
+   the instrument external name from the staging path.
 
 release 107.1.0 (2026-05-11)
  - Events are created for all run statuses. The customers are interested only

--- a/lib/Monitor/Ultimagen/RunFolder.pm
+++ b/lib/Monitor/Ultimagen/RunFolder.pm
@@ -28,8 +28,6 @@ Readonly::Scalar my $USERNAME => 'useq_pipeline';
 Readonly::Scalar my $RUN_UPLOADED_FILE => 'UploadCompleted.json';
 Readonly::Scalar my $RUN_STATUS_MIRRORED => 'run mirrored';
 
-Readonly::Scalar my $INSTRUMENT_NAME => 'V125';
-
 =head1 NAME
 
 Monitor::Ultimagen::RunFolder
@@ -61,6 +59,25 @@ has q{runfolder_path} => (
   is            => q{ro},
   required      => 1,
 );
+
+# The instrument (external) name parsed out from the
+# runfolder_path attribute.
+# Ultima does not store instrument info on disk, so 
+# we need to infer the instrument (external) name for
+# the run from the path where it writes to.
+has q{_instrument_external_name} => (
+  isa               => q{Str},
+  is                => q{ro},
+  required          => 0,
+  lazy_build        => 1,
+);
+sub _build__instrument_external_name {
+  my $self = shift;
+  my ($instrument_name) = $self->runfolder_path =~ m/staging\/(\w+)\//ms;
+  $instrument_name or croak 
+    'Failed to parse instrument name from runfolder path ' . $self->runfolder_path;
+  return $instrument_name;
+}
 
 =head2 runfolder_glob
 
@@ -113,7 +130,9 @@ sub _build_tracking_run {
   my $ultimagen_runid = $self->_get_ultimagen_run_attr('RunId');
 
   my $rs = $self->npg_tracking_schema->resultset('Run');
-  my $run_row = $rs->find_with_attributes($ultimagen_runid, $INSTRUMENT_NAME);
+  my $run_row = $rs->find_with_attributes(
+    $ultimagen_runid,
+    $self->tracking_instrument()->external_name);
   if ($run_row) {
     $self->info('Found run ' . $run_row->folder_name . ' with ID ' . $run_row->id_run);
     if ($run_row->folder_name ne $self->folder_name) {
@@ -170,15 +189,14 @@ has q{tracking_instrument} => (
 sub _build_tracking_instrument {
   my $self = shift;
   my $rs = $self->npg_tracking_schema->resultset('Instrument');
-  my $params = {
-    external_name => $INSTRUMENT_NAME
-  };
-  my @instrument_rows = $rs->search($params)->all();
+  my @instrument_rows = grep {
+    $_->manufacturer_is_UltimaGenomics()
+  } $rs->search({external_name => $self->_instrument_external_name})->all();
 
   my $instrument_count = scalar @instrument_rows;
   if ($instrument_count != 1) {
     $self->logcroak('No current or multiple instruments found in NPG tracking DB with name '
-      . $INSTRUMENT_NAME);
+      . $self->_instrument_external_name);
   }
 
   my $instrument_row = $instrument_rows[0];
@@ -350,7 +368,7 @@ __END__
 
 =head1 LICENSE AND COPYRIGHT
 
-Copyright (C) 2025 Genome Research Ltd.
+Copyright (C) 2025, 2026 Genome Research Ltd.
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/lib/Monitor/Ultimagen/Staging.pm
+++ b/lib/Monitor/Ultimagen/Staging.pm
@@ -38,7 +38,7 @@ Utilities to interrogate the staging area designated to an Ultimagen instrument.
 Find valid run folders for Ultimagen runs in a top folder (or staging area).
 A valid run folder has RunID_LibraryInfo.xml file.
 
-The path pattern matches [staging_area]/Runs/[run_folder]
+The path pattern matches .../staging/[instrument_name]/[run_folder]
 
 A list of run folder paths is returned.
 =cut

--- a/t/37-ultimagen-monitor-runfolder.t
+++ b/t/37-ultimagen-monitor-runfolder.t
@@ -3,7 +3,7 @@ use warnings;
 use File::Basename;
 use File::Copy;
 use File::Copy::Recursive qw( dircopy );
-use Test::More tests => 4;
+use Test::More tests => 5;
 use Test::Exception;
 use File::Temp qw( tempdir );
 use File::Path qw( make_path );
@@ -25,7 +25,7 @@ subtest 'test error conditions' => sub {
   my $run_folder_name = "${ultimagen_runid}-${date}";
   my $nodate_folder_name = "${ultimagen_runid}_1212";
   my $data_folder = catdir('t/data/ultimagen_staging/Runs', $run_folder_name);
-  my $runfolder_path = catdir($testdir, 'Runs', $nodate_folder_name);
+  my $runfolder_path = catdir($testdir, 'staging/V125', $nodate_folder_name);
   dircopy($data_folder, $runfolder_path) or die "cannot copy test directory $!";
 
   my $test = Monitor::Ultimagen::RunFolder->new(
@@ -43,8 +43,8 @@ subtest 'test error conditions' => sub {
   my $run_folder_name1 = "${ultimagen_runid}-${date}";
   my $run_folder_name2 = "RE-${ultimagen_runid}-${date}";
   $data_folder = catdir('t/data/ultimagen_staging/Runs', $run_folder_name1);
-  my $runfolder_path1 = catdir($testdir, 'Runs', $run_folder_name1);
-  my $runfolder_path2 = catdir($testdir, 'Runs', $run_folder_name2);
+  my $runfolder_path1 = catdir($testdir, 'staging/V125', $run_folder_name1);
+  my $runfolder_path2 = catdir($testdir, 'staging/V125', $run_folder_name2);
   dircopy($data_folder, $runfolder_path1) or die "cannot copy test directory $!";
   dircopy($data_folder, $runfolder_path2) or die "cannot copy test directory $!";
 
@@ -71,7 +71,7 @@ subtest 'test tracking update on new run' => sub {
   my $ultimagen_runid = '424090';
   my $run_folder_name = "${ultimagen_runid}-${date}";
   my $data_folder = catdir('t/data/ultimagen_staging/Runs', $run_folder_name);
-  my $runfolder_path = catdir($testdir, 'Runs', $run_folder_name);
+  my $runfolder_path = catdir($testdir, 'staging/V125', $run_folder_name);
   dircopy($data_folder, $runfolder_path) or die "cannot copy test directory $!";
 
   my $test = Monitor::Ultimagen::RunFolder->new( runfolder_path      => $runfolder_path,
@@ -112,7 +112,7 @@ subtest 'test on status progress' =>  sub {
   my $ultimagen_runid = '424090';
   my $run_folder_name = "${ultimagen_runid}-${date}";
   my $data_folder = catdir('t/data/ultimagen_staging/Runs', $run_folder_name);
-  my $runfolder_path = catdir($testdir, 'Runs', $run_folder_name);
+  my $runfolder_path = catdir($testdir, 'staging/V125', $run_folder_name);
   my $upload_completed_path = catfile($runfolder_path, 'UploadCompleted.json');
   dircopy($data_folder, $runfolder_path) or die "cannot copy test directory $!";
 
@@ -139,6 +139,70 @@ subtest 'test on status progress' =>  sub {
 
   lives_ok {$test->process_run();} 'process_run succeeds on early return';
   is( $test->tracking_run()->current_run_status_description, 'run mirrored', 'status on run mirrored after early return');
+};
+
+subtest 'test on instrument name parsed out from the staging area path' => sub {
+  plan tests => 8;
+
+  my $schema  = t::dbic_util->new->test_schema();
+  my $testdir = tempdir( CLEANUP => 1 );
+  my $run_folder_name = '424090-20250822_0117';
+
+  my $staging_path = catdir($testdir, 'staging', 'UNKNOWN', $run_folder_name);
+  make_path($staging_path);
+  my $test = Monitor::Ultimagen::RunFolder->new(
+    runfolder_path      => $staging_path,
+    npg_tracking_schema => $schema,
+  );
+  throws_ok {$test->tracking_instrument()->external_name}
+    qr/No[ ]current[ ]or[ ]multiple[ ]instruments[ ]found[ ]in[ ]NPG[ ]tracking[ ]DB[ ]with[ ]name[ ]UNKNOWN/,
+    'Unknown instrument name returned when staging path has no known instrument';
+
+  my $instrument_name = 'U010';
+  my $instr_path = catdir($testdir, 'staging', $instrument_name, $run_folder_name);
+  make_path($instr_path);
+  $test = Monitor::Ultimagen::RunFolder->new(
+    runfolder_path      => $instr_path,
+    npg_tracking_schema => $schema,
+  );
+  is($test->tracking_instrument()->external_name, $instrument_name,
+    'instrument external name parsed from staging path');
+  is($test->tracking_instrument()->name, 'UG2',
+    'instrument name correct');
+  ok($test->tracking_instrument()->manufacturer_is_UltimaGenomics(),
+    'instrument manufacturer name correct');
+  is($test->tracking_instrument()->instrument_format->model, 'UG 200',
+    'instrument model correct');
+
+  my $instr_path = catdir($testdir, $instrument_name, $run_folder_name);
+  make_path($instr_path);
+  $test = Monitor::Ultimagen::RunFolder->new(
+    runfolder_path      => $instr_path,
+    npg_tracking_schema => $schema,
+  );
+  throws_ok {$test->tracking_instrument()->external_name}
+    qr/Failed[ ]to[ ]parse[ ]instrument[ ]name[ ]from[ ]runfolder[ ]path[ ]$instr_path/,
+    "No 'staging' component in the runfolder path";
+
+  my $instr_path = catdir($testdir, $instrument_name, 'staging', 'otherfolder', $run_folder_name);
+  make_path($instr_path);
+  $test = Monitor::Ultimagen::RunFolder->new(
+    runfolder_path      => $instr_path,
+    npg_tracking_schema => $schema,
+  );
+  throws_ok {$test->tracking_instrument()->external_name}
+    qr/No[ ]current[ ]or[ ]multiple[ ]instruments[ ]found[ ]in[ ]NPG[ ]tracking[ ]DB[ ]with[ ]name[ ]otherfolder/,
+    "'staging' component in the wrong position";
+  
+  my $instr_path = catdir($testdir, $instrument_name, $run_folder_name, 'staging');
+  make_path($instr_path);
+  $test = Monitor::Ultimagen::RunFolder->new(
+    runfolder_path      => $instr_path,
+    npg_tracking_schema => $schema,
+  );
+  throws_ok {$test->tracking_instrument()->external_name}
+    qr/Failed[ ]to[ ]parse[ ]instrument[ ]name[ ]from[ ]runfolder[ ]path[ ]$instr_path/,
+    "'staging' component at the end of the path"; 
 };
 
 1;

--- a/t/data/dbic_fixtures/100-InstrumentFormat.yml
+++ b/t/data/dbic_fixtures/100-InstrumentFormat.yml
@@ -75,3 +75,9 @@
   iscurrent: 1
   default_columns: 0
   default_tiles: 0
+- id_instrument_format: 26
+  id_manufacturer: 22
+  model: 'UG 200'
+  iscurrent: 1
+  default_columns: 0
+  default_tiles: 0

--- a/t/data/dbic_fixtures/200-Instrument.yml
+++ b/t/data/dbic_fixtures/200-Instrument.yml
@@ -174,3 +174,16 @@
   latest_contact:
   percent_complete:
   lab:
+- external_name: U010
+  id_instrument: 131
+  id_instrument_format: 26
+  serial: ''
+  name: UG2
+  iscurrent: 1
+  ipaddr: ''
+  instrument_comp: ''
+  mirroring_host:
+  staging_dir:
+  latest_contact:
+  percent_complete:
+  lab:


### PR DESCRIPTION
Allow the staging monitor to read the instrument (external) name from the path where the instrument writes to. If no `instrument_name` is parsed out it should exit with error as the staging path is the only source where to get the name.