### PR TITLE
restrict interpreter reuse in apache

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,10 @@
 LIST OF CHANGES
 
+ - Crypt pbkdf2 library has an known issue. Trying to import multiple times
+   the same module causing issues with perl interpreter. Limiting the re-use of
+   child processes is a workaround until the library is fixed or we
+   discontinue the use.
+
 release 107.2.0 (2026-06-01)
  - Fix the staging area path for Ultimagen 'UG 200' instrument in the daemon.
    The external name 'U10' is now updated to 'U010'.

--- a/wtsi_local/httpd.conf
+++ b/wtsi_local/httpd.conf
@@ -151,7 +151,7 @@ Group ${APACHE_RUN_GROUP}
     ServerLimit            50
     ThreadsPerChild         1
     MaxRequestWorkers      50
-    MaxConnectionsPerChild 50
+    MaxConnectionsPerChild  1
 </IfModule>
 
 <IfModule mpm_event_module>
@@ -166,7 +166,7 @@ Group ${APACHE_RUN_GROUP}
     MaxRequestWorkers      1280
     MinSpareThreads         256
     MaxSpareThreads         512
-    MaxConnectionsPerChild 2048
+    MaxConnectionsPerChild    1
 </IfModule>
 
 


### PR DESCRIPTION
We have an issue with interpreter complaining about Crypt library trying to reload modules.

Introducing this a workaround.